### PR TITLE
Node Parameterを開いたときにグラフが左に移動するバグを修正する

### DIFF
--- a/Assets/Rector/StaticResources/UI/StyleSheets/RectorStyles.uss
+++ b/Assets/Rector/StaticResources/UI/StyleSheets/RectorStyles.uss
@@ -176,8 +176,6 @@
     height: 100%;
     position: absolute;
     transform-origin: left top;
-    top: 50%;
-    left: 50%;
 }
 
 .rector-graph-content-animation {


### PR DESCRIPTION
StyleSheetでtopとleftを50%にしたのが原因だった

fix https://scrapbox.io/Rector/Node_Parameter%E3%82%92%E9%96%8B%E3%81%84%E3%81%9F%E3%81%A8%E3%81%8D%E3%81%AB%E3%82%B0%E3%83%A9%E3%83%95%E3%81%8C%E5%B7%A6%E3%81%AB%E7%A7%BB%E5%8B%95%E3%81%97%E3%81%A6%E3%81%97%E3%81%BE%E3%81%86