### PR TITLE
feat: Add auto-scroll to copyright notices

### DIFF
--- a/Assets/Rector/Scripts/UI/Hud/CopyrightNoticesPageView.cs
+++ b/Assets/Rector/Scripts/UI/Hud/CopyrightNoticesPageView.cs
@@ -13,6 +13,8 @@ namespace Rector.UI.Hud
         readonly UIInputAction uiInputAction;
         CopyrightNoticesPageModel model;
         readonly SerialDisposable inputDisposable = new();
+        readonly SerialDisposable scrollDisposable = new();
+        const float ScrollSpeed = 50f;
 
         public CopyrightNoticesPageView(VisualElement root, UIInputAction uiInputAction)
         {
@@ -37,6 +39,7 @@ namespace Rector.UI.Hud
         {
             root.style.display = DisplayStyle.None;
             inputDisposable.Disposable = null;
+            scrollDisposable.Disposable = null;
             label.text = "";
             uiInputAction.Unregister(this);
         }
@@ -47,6 +50,16 @@ namespace Rector.UI.Hud
             label.text = await model.LoadCopyrightNoticesAsync();
             label.transform.position = new Vector3(0, 0, 0);
             uiInputAction.Register(this);
+
+            scrollDisposable.Disposable = Observable.Timer(TimeSpan.FromSeconds(1))
+                .SelectMany(_ => Observable.EveryUpdate())
+                .Subscribe(_ =>
+                {
+                    var pos = label.transform.position;
+                    pos.y -= ScrollSpeed * Time.deltaTime;
+                    pos.y = Mathf.Clamp(pos.y, root.resolvedStyle.height - label.resolvedStyle.height, 0f);
+                    label.transform.position = pos;
+                });
         }
 
         void MoveLabel(float y)


### PR DESCRIPTION
## Summary
- Add automatic scrolling to the copyright notices page

## Changes
- Add auto-scroll functionality that starts 1 second after the page is displayed
- Scroll speed is set to 50 pixels per second
- Scrolling automatically stops when reaching the bottom of the content
- Manual scrolling with input controls still works as before

## Implementation Details
- Added `scrollDisposable` to manage the auto-scroll subscription
- Used `Observable.Timer` to delay the start of scrolling by 1 second
- Used `Observable.EveryUpdate` for smooth frame-based scrolling
- Properly dispose of the scroll subscription when hiding the page

## Test plan
- [x] Open the copyright notices page from the HUD
- [x] Verify auto-scroll starts after 1 second
- [x] Verify scrolling stops at the bottom
- [x] Verify manual scrolling with input still works
- [x] Verify no memory leaks when repeatedly opening/closing the page

🤖 Generated with [Claude Code](https://claude.ai/code)