### PR TITLE
feat: Change HudStyleNode from RGB to HSV color input

### DIFF
--- a/Assets/Rector/Scripts/UI/Graphs/Nodes/HudStyleNode.cs
+++ b/Assets/Rector/Scripts/UI/Graphs/Nodes/HudStyleNode.cs
@@ -53,8 +53,12 @@ namespace Rector.UI.Graphs.Nodes
             hudModel.FrameColor.Subscribe(c =>
             {
                 Color.RGBToHSV(c, out var hue, out var saturation, out var value);
-                h.Value.Value = hue;
-                s.Value.Value = saturation;
+                // V=0の時はH,Sの値を更新しない（黒色で彩度情報が失われるため）
+                if (value > 0)
+                {
+                    h.Value.Value = hue;
+                    s.Value.Value = saturation;
+                }
                 v.Value.Value = value;
                 a.Value.Value = c.a;
             }).AddTo(disposable);


### PR DESCRIPTION
## Summary
- HudStyleNodeの色入力をRGBからHSVに変更しました
- より直感的な色の操作が可能になります

## Changes
- RGB入力 (R,G,B) をHSV入力 (H,S,V) に変更
- HSVからRGBへの変換処理を実装
- RGBからHSVへの変換処理を実装（双方向同期）
- アルファチャンネルの機能は維持

## Test plan
- [x] HudStyleNodeが正常に作成できることを確認
- [x] HSV値を変更して色が正しく反映されることを確認
- [x] HUDモデルの色変更がHSV入力に正しく反映されることを確認
- [x] アルファチャンネルが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)