### PR TITLE
Migrate VisualElement.transform to USS transform properties

### DIFF
--- a/Assets/Rector/Scripts/UI/GraphPages/CreateNodeMenuView.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/CreateNodeMenuView.cs
@@ -89,7 +89,7 @@ namespace Rector.UI.GraphPages
 
         public void SetPosition(Vector2 position)
         {
-            root.transform.position = position;
+            root.style.translate = position;
         }
 
         public void Navigate(Vector2 value)

--- a/Assets/Rector/Scripts/UI/GraphPages/GraphContentTransformer.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/GraphContentTransformer.cs
@@ -21,6 +21,10 @@ namespace Rector.UI.GraphPages
         const float MinScale = 0.5f;
         Vector2 offset;
 
+        // resolvedStyle はレイアウト解決後にしか更新されないため、
+        // 加減算で読み戻さずに済むよう平行移動量を保持する。
+        Vector2 translation;
+
         Vector2 MaskSizeHalf => new(mask.resolvedStyle.width * 0.5f, mask.resolvedStyle.height * 0.5f);
 
         public GraphContentTransformer(VisualElement mask, VisualElement content, GraphInputAction graphInputAction)
@@ -52,13 +56,19 @@ namespace Rector.UI.GraphPages
             content.AddToClassList(AnimationClassName);
         }
 
+        void SetTranslation(Vector2 value)
+        {
+            translation = value;
+            content.style.translate = value;
+        }
+
         void Reset()
         {
             DisableAnimation();
             currentScale = 1f;
             offset = Vector2.zero;
-            content.transform.position = MaskSizeHalf;
-            content.transform.scale = Vector3.one;
+            SetTranslation(MaskSizeHalf);
+            content.style.scale = Vector3.one;
         }
 
         void ApplyZoom(float zoom)
@@ -67,14 +77,14 @@ namespace Rector.UI.GraphPages
             var delta = Time.deltaTime * Mathf.Sign(zoom);
             currentScale = Mathf.Clamp(currentScale + delta, MinScale, MaxScale);
             var scale = new Vector3(currentScale, currentScale, 1f);
-            content.transform.scale = scale;
+            content.style.scale = scale;
 
             // maskの中心が移動した分だけcontentを移動させることでmaskの中心をズームする
             var maskCenter = mask.worldBound.center;
             var contentLeftUp = new Vector2(content.worldBound.xMin, content.worldBound.yMin);
             var centerPosition = maskCenter - contentLeftUp;
             var diff = centerPosition * (currentScale / beforeScale - 1f);
-            content.transform.position -= new Vector3(diff.x, diff.y);
+            SetTranslation(translation - diff);
         }
 
 
@@ -107,16 +117,16 @@ namespace Rector.UI.GraphPages
 
         void ApplyTranslate(Vector2 translate)
         {
-            var delta = new Vector3(translate.x, -translate.y, 0f) * 10f;
-            content.transform.position += delta;
-            offset += new Vector2(delta.x, delta.y);
+            var delta = new Vector2(translate.x, -translate.y) * 10f;
+            SetTranslation(translation + delta);
+            offset += delta;
         }
 
         public void MoveContentToMakeNodeVisible(LayeredNode node)
         {
             // left-top
             var nodePosition = node.TargetPosition * currentScale;
-            content.transform.position = -nodePosition + MaskSizeHalf + offset;
+            SetTranslation(-nodePosition + MaskSizeHalf + offset);
         }
 
         public void Dispose()

--- a/Assets/Rector/Scripts/UI/Graphs/Nodes/NodeView.cs
+++ b/Assets/Rector/Scripts/UI/Graphs/Nodes/NodeView.cs
@@ -22,13 +22,14 @@ namespace Rector.UI.Graphs.Nodes
 
         protected readonly CompositeDisposable Disposables = new();
 
+        // アニメーション中は補間中の現在値を返す。目標値が要る場合は TargetPosition を使う。
         public Vector2 Position
         {
-            get => Root.transform.position;
+            get => Root.resolvedStyle.translate;
             set
             {
                 TargetPosition = value;
-                Root.transform.position = new Vector3(value.x, value.y, 0);
+                Root.style.translate = value;
             }
         }
 

--- a/Assets/Rector/Scripts/UI/Hud/CopyrightNoticesPageView.cs
+++ b/Assets/Rector/Scripts/UI/Hud/CopyrightNoticesPageView.cs
@@ -16,6 +16,10 @@ namespace Rector.UI.Hud
         readonly SerialDisposable scrollDisposable = new();
         const float ScrollSpeed = 50f;
 
+        // resolvedStyle はレイアウト解決後にしか更新されないため、
+        // 読み戻さずに済むようスクロール位置を保持する。x は常に 0。
+        float scrollY;
+
         public CopyrightNoticesPageView(VisualElement root, UIInputAction uiInputAction)
         {
             this.root = root;
@@ -48,26 +52,25 @@ namespace Rector.UI.Hud
         {
             root.style.display = DisplayStyle.Flex;
             label.text = await model.LoadCopyrightNoticesAsync();
-            label.transform.position = new Vector3(0, 0, 0);
+            // ここではクランプしない。text 代入直後で resolvedStyle.height が未確定のため。
+            scrollY = 0f;
+            label.style.translate = Vector2.zero;
             uiInputAction.Register(this);
 
             scrollDisposable.Disposable = Observable.Timer(TimeSpan.FromSeconds(1))
                 .SelectMany(_ => Observable.EveryUpdate())
-                .Subscribe(_ =>
-                {
-                    var pos = label.transform.position;
-                    pos.y -= ScrollSpeed * Time.deltaTime;
-                    pos.y = Mathf.Clamp(pos.y, root.resolvedStyle.height - label.resolvedStyle.height, 0f);
-                    label.transform.position = pos;
-                });
+                .Subscribe(_ => SetScrollY(scrollY - ScrollSpeed * Time.deltaTime));
+        }
+
+        void SetScrollY(float y)
+        {
+            scrollY = Mathf.Clamp(y, root.resolvedStyle.height - label.resolvedStyle.height, 0f);
+            label.style.translate = new Vector2(0f, scrollY);
         }
 
         void MoveLabel(float y)
         {
-            var pos = label.transform.position;
-            pos.y += y * 10;
-            pos.y = Mathf.Clamp(pos.y, root.resolvedStyle.height - label.resolvedStyle.height, 0f);
-            label.transform.position = pos;
+            SetScrollY(scrollY + y * 10);
         }
 
         void IUIInputHandler.OnNavigate(Vector2 value)


### PR DESCRIPTION
Closes #31.

`VisualElement.transform` and `ITransform.position` became obsolete in Unity 6.3. Writes move to `style.translate` / `style.scale`, reads to `resolvedStyle.translate`.

## Two corrections to the issue

**It is 14 sites, not 219.** 219 was the `CS0618` count in `Editor.log`: each site emits two warnings (one for `VisualElement.transform`, one for `ITransform.position`) and the log accumulates them across recompiles. Unique `file:line` count is 14.

**No `Translate` / `Scale` value needs to be constructed.** The issue said `style.translate` requires a `Translate` built from `Length` values. Disassembling the shipped `UnityEngine.UIElementsModule.dll` shows implicit conversions that make the call sites plain assignments:

```
StyleTranslate: op_Implicit(Vector2) / op_Implicit(Vector3)
StyleScale:     op_Implicit(Vector2) / op_Implicit(Vector3) / op_Implicit(Scale)
IResolvedStyle.translate -> Vector3
Length::op_Implicit(float32) -> LengthUnit 0 (Pixel)
```

## Why some sites hold a field instead

Reads and writes now land on different properties, and `resolvedStyle` only updates once layout resolves — so reading back a value written in the same frame can return a stale one. Where a value was only read in order to modify it, it is held in a field:

- **`GraphContentTransformer`** gains `translation` and `SetTranslation()`, alongside the `currentScale` / `offset` fields it already had. The two compound assignments — pan delta and zoom recentering — compute from that field.
- **`CopyrightNoticesPageView`** gains `scrollY`. The clamp was duplicated across the auto-scroll and the input path; both now go through `SetScrollY()`.

## Why NodeView is not converted

`NodeView.Position` and `TargetPosition` mean different things and are used for different things:

| | meaning | read by |
|---|---|---|
| `Position` | value mid-transition | `GraphPage` — node creation menu placement, hold guide |
| `TargetPosition` | destination | `NodeNavigator` — node ordering, `GraphContentTransformer` |

USS animates `translate` for both nodes and graph content (`RectorNode.uss:6-9` 0.2s ease-in-out, `RectorStyles.uss:181-185` 0.1s linear). Collapsing `Position` onto a stored field would make it return the destination and shift where the menu and hold guide appear while a node is moving. Its getter keeps reading the resolved value.

## Verification

- Recompiled in 6000.3.21f1: **0 compile errors, 0 `CS0618`**, no new warnings of any kind
- Play Mode entered with no exceptions
- `dotnet format Rector.csproj` produced no further changes

**Still needs a manual pass:** `ApplyZoom` writes scale and then reads `content.worldBound` on the next lines. `transform.scale` may have been visible to `worldBound` immediately where `style.scale` only applies once layout resolves. The write/read order is left exactly as it was to keep the change minimal, but zoom recentering should be exercised in the editor. If the zoom drifts off the mask center, the fix is to read `worldBound` before writing scale, or to derive the bounds from `currentScale` arithmetically.

Unrelated to this branch: UI Toolkit currently does not render in macOS standalone builds (input and layout still work, scene and VFX render). Shader stripping has been ruled out — the UI Toolkit shaders are present in `unity_builtin_extra`. Being tracked separately.