### PR TITLE
Fix UI Toolkit not rendering in standalone builds

### DIFF
--- a/Assets/Rector/Settings/RectorPanelSettings.asset
+++ b/Assets/Rector/Settings/RectorPanelSettings.asset
@@ -17,7 +17,8 @@ MonoBehaviour:
   m_DisableNoThemeWarning: 0
   m_TargetTexture: {fileID: 0}
   m_RenderMode: 0
-  m_WorldSpaceLayer: 0
+  m_ColliderUpdateMode: 0
+  m_ColliderIsTrigger: 1
   m_ScaleMode: 2
   m_ReferenceSpritePixelsPerUnit: 100
   m_PixelsPerUnit: 100
@@ -30,18 +31,25 @@ MonoBehaviour:
   m_SortingOrder: 0
   m_TargetDisplay: 0
   m_BindingLogLevel: 0
-  m_ClearDepthStencil: 0
+  m_ClearDepthStencil: 1
   m_ClearColor: 0
   m_ColorClearValue: {r: 0, g: 0, b: 0, a: 0}
   m_VertexBudget: 0
+  m_TextureSlotCount: 8
   m_DynamicAtlasSettings:
     m_MinAtlasSize: 64
     m_MaxAtlasSize: 4096
     m_MaxSubTextureSize: 64
     m_ActiveFilters: -1
   m_AtlasBlitShader: {fileID: 9101, guid: 0000000000000000f000000000000000, type: 0}
-  m_RuntimeShader: {fileID: 9100, guid: 0000000000000000f000000000000000, type: 0}
-  m_RuntimeWorldShader: {fileID: 9102, guid: 0000000000000000f000000000000000, type: 0}
+  m_DefaultShader: {fileID: 9100, guid: 0000000000000000f000000000000000, type: 0}
+  m_RuntimeGaussianBlurShader: {fileID: 20300, guid: 0000000000000000f000000000000000,
+    type: 0}
+  m_RuntimeColorEffectShader: {fileID: 20301, guid: 0000000000000000f000000000000000,
+    type: 0}
+  m_SDFShader: {fileID: 19011, guid: 0000000000000000f000000000000000, type: 0}
+  m_BitmapShader: {fileID: 9001, guid: 0000000000000000f000000000000000, type: 0}
+  m_SpriteShader: {fileID: 19012, guid: 0000000000000000f000000000000000, type: 0}
   m_ICUDataAsset: {fileID: 0}
   forceGammaRendering: 0
   textSettings: {fileID: 11400000, guid: ed1c256514a62b749ad638d7271e10f8, type: 2}


### PR DESCRIPTION
UI Toolkit drew nothing in macOS standalone builds. Fixed by two changes to `RectorPanelSettings`.

## Symptom

- Scene and VFX rendered normally; BG scene switching worked
- Input and hit-testing worked, so the panel was alive and its layout was correct
- Only the UI pixels never landed
- Reproduced in release and development builds, never in the editor
- Predates the 6.3 upgrade — toggling fullscreen used to recover it, which stopped working after upgrading

## What the Frame Debugger showed

The draws were being issued, and every part of their state looked right:

| | |
|---|---|
| Pass | `(RP 11:1) DrawScreenSpaceUI`, 6 draw calls |
| Shader | `Hidden/Internal-UIRDefault` |
| Blend | `SrcAlpha / OneMinusSrcAlpha`, BlendOp Add |
| ColorMask | RGBA |
| Geometry | 54 vertices, 30 indices |
| RenderTarget | Attachment 1, 1824x940 — matching the Metal surface in `Player.log` |

Every draw wrote zero pixels.

## Ruled out along the way

- **Initialization failure** — input works, so the composition root completed
- **Layout / panel scale** — hit-testing lands correctly. `ResolveScale` for `Shrink` is `Min(rect.width/refW, rect.height/refH)`, which for the observed sizes gives a panel that fills the target
- **Shader stripping** — `Hidden/Internal-UIRDefault` and `Hidden/Internal-UIRAtlasBlitCopy` are both present in the build's `Resources/unity_builtin_extra`
- **Window aspect ratio** — an early run had a portrait 1280x2762 surface, but the bug persists at 1824x940 landscape
- **URP rendering** — scene, VFX and post-processing all draw
- **`GUITexture.Draw` after `ExecuteRenderGraph`** — that is the development build indicator

## The fix

Two things were wrong with the asset. **Which one was load-bearing has not been isolated** — both are carried here.

**1. `clearDepthStencil` was false.** Unity's default is true, verified against the field initializer in `UnityEngine.UIElementsModule`. UI Toolkit clips through the stencil buffer, and these draws ran `Stencil Comp Equal` against `Ref 0`. The pass reported no depth/stencil actions at all, which is consistent with no stencil attachment being allocated for it.

**2. The asset was still serialized against the pre-6.3 schema.** Opening it in the Inspector migrated it:

```
- m_WorldSpaceLayer            + m_ColliderUpdateMode, m_ColliderIsTrigger
                               + m_TextureSlotCount
- m_RuntimeShader              + m_DefaultShader
- m_RuntimeWorldShader         + m_RuntimeGaussianBlurShader
                               + m_RuntimeColorEffectShader
                               + m_SDFShader
                               + m_BitmapShader
                               + m_SpriteShader
```

Five shader slots — gaussian blur, color effect, SDF, bitmap, sprite — had no entry at all before the migration.

To isolate which change mattered, set `m_ClearDepthStencil` back to `0` while keeping the migrated schema and rebuild.

## Verification

UI renders in a standalone build.