### PR TITLE
Expose Rector to the Unity CLI through CliClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,10 @@ crashlytics-build.properties
 
 # Mac
 .DS_Store
+
+# com.unity.test-framework.performance が実行のたびに書き出す生成物
+# (マシン構成と解決済みパッケージのスナップショット)
+/Assets/Resources/PerformanceTestRunInfo.json
+/Assets/Resources/PerformanceTestRunInfo.json.meta
+/Assets/Resources/PerformanceTestRunSettings.json
+/Assets/Resources/PerformanceTestRunSettings.json.meta

--- a/Assets/Rector/Scenes/Base.unity
+++ b/Assets/Rector/Scenes/Base.unity
@@ -283,6 +283,7 @@ MonoBehaviour:
   - {fileID: 19034544}
   - {fileID: 19034545}
   guid: 0aa03a44-f14d-43f7-8559-01cce2a5a940
+  category: 5
   cameraInputSlot: {fileID: 19034546}
 --- !u!114 &19034544
 MonoBehaviour:
@@ -429,6 +430,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -450,9 +453,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!33 &20401576
 MeshFilter:
@@ -674,6 +679,7 @@ MonoBehaviour:
   - {fileID: 194669239}
   - {fileID: 194669240}
   guid: fd7102b7-9c18-4a8d-9cee-aabd90edc839
+  category: 5
   cameraInputSlot: {fileID: 194669241}
 --- !u!114 &194669239
 MonoBehaviour:
@@ -955,6 +961,7 @@ MonoBehaviour:
   - {fileID: 418786977}
   - {fileID: 418786976}
   guid: dd40b01a-438c-4abd-a763-0de05228ce74
+  category: 5
   cameraInputSlot: {fileID: 418786978}
 --- !u!114 &418786976
 MonoBehaviour:
@@ -1196,6 +1203,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1217,9 +1226,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!33 &431810040
 MeshFilter:
@@ -1441,6 +1452,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1462,9 +1475,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!33 &611200832
 MeshFilter:
@@ -1489,6 +1504,57 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &652315990
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 652315991}
+  - component: {fileID: 652315992}
+  m_Layer: 0
+  m_Name: RuntimePipelineManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &652315991
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 652315990}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &652315992
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 652315990}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dd4ab1c9091e0194196b5f5d51cb932f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.Pipeline::Unity.Pipeline.RuntimePipelineManager
+  enableInBuilds: 1
+  port: 0
+  requestTimeoutMs: 30000
+  enableAuditLogging: 1
+  autoStart: 1
+  maxWorkItemsPerFrame: 10
+  m_AllowedReloadRoots: []
 --- !u!1 &829044796
 GameObject:
   m_ObjectHideFlags: 0
@@ -1519,17 +1585,23 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Version: 3
   m_UsePipelineSettings: 1
   m_AdditionalLightsShadowResolutionTier: 2
-  m_LightLayerMask: 1
-  m_RenderingLayers: 1
   m_CustomShadowLayers: 0
-  m_ShadowLayerMask: 1
-  m_ShadowRenderingLayers: 1
   m_LightCookieSize: {x: 1, y: 1}
   m_LightCookieOffset: {x: 0, y: 0}
   m_SoftShadowQuality: 0
+  m_RenderingLayersMask:
+    serializedVersion: 0
+    m_Bits: 1
+  m_ShadowRenderingLayersMask:
+    serializedVersion: 0
+    m_Bits: 1
+  m_Version: 4
+  m_LightLayerMask: 1
+  m_ShadowLayerMask: 1
+  m_RenderingLayers: 1
+  m_ShadowRenderingLayers: 1
 --- !u!108 &829044798
 Light:
   m_ObjectHideFlags: 0
@@ -1538,14 +1610,14 @@ Light:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 829044796}
   m_Enabled: 1
-  serializedVersion: 11
+  serializedVersion: 12
   m_Type: 2
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_Intensity: 1.5
   m_Range: 10
   m_SpotAngle: 30
   m_InnerSpotAngle: 21.80208
-  m_CookieSize: 10
+  m_CookieSize2D: {x: 10, y: 10}
   m_Shadows:
     m_Type: 2
     m_Resolution: -1
@@ -1791,6 +1863,7 @@ MonoBehaviour:
   - {fileID: 868003835}
   - {fileID: 868003836}
   guid: de5ac1c8-1c38-454e-bd58-f75920184ac8
+  category: 5
   cameraInputSlot: {fileID: 868003837}
 --- !u!114 &868003835
 MonoBehaviour:
@@ -1930,6 +2003,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1951,9 +2026,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!33 &938920419
 MeshFilter:
@@ -2056,7 +2133,6 @@ MonoBehaviour:
   m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
   m_RequiresDepthTexture: 0
   m_RequiresColorTexture: 0
-  m_Version: 2
   m_TaaSettings:
     m_Quality: 3
     m_FrameInfluence: 0.1
@@ -2064,6 +2140,7 @@ MonoBehaviour:
     m_MipBias: 0
     m_VarianceClampScale: 0.9
     m_ContrastAdaptiveSharpening: 0
+  m_Version: 2
 --- !u!81 &961739751
 AudioListener:
   m_ObjectHideFlags: 0
@@ -2317,9 +2394,13 @@ MonoBehaviour:
   sourceAsset: {fileID: 9197481963319205126, guid: 1d5d0b6cd95bfdf44b2a3b3949b7e34e,
     type: 3}
   m_SortingOrder: 0
+  m_Position: 0
   m_WorldSpaceSizeMode: 1
   m_WorldSpaceWidth: 1920
   m_WorldSpaceHeight: 1080
+  m_PivotReferenceSize: 0
+  m_Pivot: 0
+  m_WorldSpaceCollider: {fileID: 0}
 --- !u!4 &1141867452
 Transform:
   m_ObjectHideFlags: 0
@@ -2511,6 +2592,7 @@ MonoBehaviour:
   - {fileID: 1219071081}
   - {fileID: 1219071082}
   guid: ed23166d-702e-4a57-89db-f25cae4e41f5
+  category: 5
   cameraInputSlot: {fileID: 1219071083}
 --- !u!114 &1219071081
 MonoBehaviour:
@@ -2761,6 +2843,7 @@ MonoBehaviour:
   - {fileID: 1275581335}
   - {fileID: 1275581334}
   guid: 23b921b8-b0c0-4394-9335-f1101d07de17
+  category: 5
   cameraInputSlot: {fileID: 1275581336}
 --- !u!114 &1275581334
 MonoBehaviour:
@@ -2938,6 +3021,7 @@ MonoBehaviour:
   - {fileID: 1312409706}
   - {fileID: 1312409705}
   guid: 1ebe8b5d-fcea-4aab-855d-bcea044022d1
+  category: 5
   cameraInputSlot: {fileID: 1312409706}
 --- !u!114 &1312409705
 MonoBehaviour:
@@ -3119,6 +3203,7 @@ MonoBehaviour:
   slotBehaviours:
   - {fileID: 1364943582}
   guid: a93f01c8-de6b-4728-a5dc-416d3c41f0df
+  category: 5
   cameraInputSlot: {fileID: 1364943582}
 --- !u!114 &1364943582
 MonoBehaviour:
@@ -3389,6 +3474,7 @@ MonoBehaviour:
   - {fileID: 1431009465}
   - {fileID: 1431009467}
   guid: 9a0efca5-0abc-4d24-9dd2-b01f4b177244
+  category: 5
   cameraInputSlot: {fileID: 1431009468}
 --- !u!114 &1431009467
 MonoBehaviour:
@@ -3756,6 +3842,7 @@ MonoBehaviour:
   - {fileID: 1792300581}
   - {fileID: 1792300579}
   guid: 589308a0-2e5e-413f-824c-3cc92854503c
+  category: 5
   cameraInputSlot: {fileID: 1792300583}
 --- !u!114 &1792300581
 MonoBehaviour:
@@ -3915,6 +4002,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -3936,9 +4025,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!33 &1912550546
 MeshFilter:
@@ -4039,6 +4130,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4060,9 +4153,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!33 &1940203304
 MeshFilter:
@@ -4221,6 +4316,7 @@ MonoBehaviour:
   - {fileID: 1970195325}
   - {fileID: 1970195324}
   guid: ec175a33-410b-4e37-9291-35f5e0543be0
+  category: 5
   cameraInputSlot: {fileID: 1970195325}
 --- !u!114 &1970195324
 MonoBehaviour:
@@ -4434,6 +4530,7 @@ SceneRoots:
   - {fileID: 1859786337}
   - {fileID: 1141867452}
   - {fileID: 463492732}
+  - {fileID: 652315991}
   - {fileID: 134190178}
   - {fileID: 20401573}
   - {fileID: 938920420}

--- a/Assets/Rector/Scripts/Cli.meta
+++ b/Assets/Rector/Scripts/Cli.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f7ca680a01aa2462fbb2a277cccefe05
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Rector/Scripts/Cli/CliClient.Commands.cs
+++ b/Assets/Rector/Scripts/Cli/CliClient.Commands.cs
@@ -1,0 +1,90 @@
+using Unity.Pipeline.Commands;
+
+namespace Rector.Cli
+{
+    /// <summary>
+    /// CliClient の CLI コマンド定義。
+    /// 実処理は CliClient のインスタンスメソッド側に置き、ここは Instance への
+    /// ディスパッチと引数の宣言だけに留める。
+    /// </summary>
+    public sealed partial class CliClient
+    {
+        [CliCommand("rector_state", "Current camera, background scene, graph size and selection.")]
+        static object StateCommand() => Call(c => c.GetState());
+
+        [CliCommand("rector_graph", "Full node graph: every node with its slots, plus every edge.")]
+        static object GraphCommand() => Call(c => c.GetGraph());
+
+        [CliCommand("rector_node_templates", "Node templates available to rector_create_node.")]
+        static object NodeTemplatesCommand() => Call(c => c.GetNodeTemplates());
+
+        [CliCommand("rector_vfx", "All VFX loaded by VfxManager.")]
+        static object VfxCommand() => Call(c => c.GetVfx());
+
+        [CliCommand("rector_cameras", "Camera behaviours, which one is active, and the blend time.")]
+        static object CamerasCommand() => Call(c => c.GetCameras());
+
+        [CliCommand("rector_scenes", "Background scenes available, and the current one.")]
+        static object ScenesCommand() => Call(c => c.GetScenes());
+
+        [CliCommand("rector_create_node", "Create a node from a template and add it to the graph.")]
+        static object CreateNodeCommand(
+            [CliArg("template", "Template name, as listed by rector_node_templates.", Required = true)] string template)
+            => Call(c => c.CreateNode(template));
+
+        [CliCommand("rector_remove_node", "Remove a node and the edges attached to it.")]
+        static object RemoveNodeCommand(
+            [CliArg("id", "Node id, as listed by rector_graph.", Required = true)] uint id)
+            => Call(c => c.RemoveNode(id));
+
+        [CliCommand("rector_select_node", "Select a node, as if it had been selected in the HUD.")]
+        static object SelectNodeCommand(
+            [CliArg("id", "Node id.", Required = true)] uint id)
+            => Call(c => c.SelectNode(id));
+
+        [CliCommand("rector_set_node_muted", "Mute or unmute a node.")]
+        static object SetNodeMutedCommand(
+            [CliArg("id", "Node id.", Required = true)] uint id,
+            [CliArg("muted", "true to mute, false to unmute.", Required = true)] bool muted)
+            => Call(c => c.SetNodeMuted(id, muted));
+
+        [CliCommand("rector_invoke_node", "Invoke a node's action (Node.DoAction).")]
+        static object InvokeNodeCommand(
+            [CliArg("id", "Node id.", Required = true)] uint id)
+            => Call(c => c.InvokeNodeAction(id));
+
+        [CliCommand("rector_connect", "Connect an output slot to an input slot. Refuses loops and incompatible types.")]
+        static object ConnectCommand(
+            [CliArg("from_node", "Node id owning the output slot.", Required = true)] uint fromNode,
+            [CliArg("from_slot", "Output slot index.", Required = true)] int fromSlot,
+            [CliArg("to_node", "Node id owning the input slot.", Required = true)] uint toNode,
+            [CliArg("to_slot", "Input slot index.", Required = true)] int toSlot)
+            => Call(c => c.Connect(fromNode, fromSlot, toNode, toSlot));
+
+        [CliCommand("rector_disconnect", "Remove the edge between an output slot and an input slot.")]
+        static object DisconnectCommand(
+            [CliArg("from_node", "Node id owning the output slot.", Required = true)] uint fromNode,
+            [CliArg("from_slot", "Output slot index.", Required = true)] int fromSlot,
+            [CliArg("to_node", "Node id owning the input slot.", Required = true)] uint toNode,
+            [CliArg("to_slot", "Input slot index.", Required = true)] int toSlot)
+            => Call(c => c.Disconnect(fromNode, fromSlot, toNode, toSlot));
+
+        [CliCommand("rector_sort_graph", "Re-run the layered graph layout.")]
+        static object SortGraphCommand() => Call(c => c.SortGraph());
+
+        [CliCommand("rector_load_scene", "Load a background scene by name.")]
+        static object LoadSceneCommand(
+            [CliArg("name", "Scene name, as listed by rector_scenes.", Required = true)] string name)
+            => Call(c => c.LoadScene(name));
+
+        [CliCommand("rector_set_camera", "Activate a camera behaviour by index.")]
+        static object SetCameraCommand(
+            [CliArg("index", "Camera index, as listed by rector_cameras.", Required = true)] int index)
+            => Call(c => c.SetCamera(index));
+
+        [CliCommand("rector_toggle_vfx", "Toggle a VFX on or off by name.")]
+        static object ToggleVfxCommand(
+            [CliArg("name", "VFX name, as listed by rector_vfx.", Required = true)] string name)
+            => Call(c => c.ToggleVfx(name));
+    }
+}

--- a/Assets/Rector/Scripts/Cli/CliClient.Commands.cs
+++ b/Assets/Rector/Scripts/Cli/CliClient.Commands.cs
@@ -32,10 +32,11 @@ namespace Rector.Cli
             [CliArg("template", "Template name, as listed by rector_node_templates.", Required = true)] string template)
             => Call(c => c.CreateNode(template));
 
-        [CliCommand("rector_remove_node", "Remove a node and the edges attached to it.")]
+        [CliCommand("rector_remove_node", "Remove a node and the edges attached to it. Not undoable: requires confirm=true.")]
         static object RemoveNodeCommand(
-            [CliArg("id", "Node id, as listed by rector_graph.", Required = true)] uint id)
-            => Call(c => c.RemoveNode(id));
+            [CliArg("id", "Node id, as listed by rector_graph.", Required = true)] uint id,
+            [CliArg("confirm", "Apply the removal. Without it the call is refused.")] bool confirm = false)
+            => Call(c => c.RemoveNode(id, confirm));
 
         [CliCommand("rector_select_node", "Select a node, as if it had been selected in the HUD.")]
         static object SelectNodeCommand(

--- a/Assets/Rector/Scripts/Cli/CliClient.Commands.cs.meta
+++ b/Assets/Rector/Scripts/Cli/CliClient.Commands.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 39f0c75f003d34be4a0cadc63ea29355

--- a/Assets/Rector/Scripts/Cli/CliClient.cs
+++ b/Assets/Rector/Scripts/Cli/CliClient.cs
@@ -112,18 +112,36 @@ namespace Rector.Cli
             return new { success = true, node = ToNodeDto(nodeView.Node.Id) };
         }
 
-        object RemoveNode(uint id)
+        // HUD ではノード削除だけが長押し (NodeSelectionInputHandler)。エッジ削除も
+        // シーン切替も単押しなので、Rector 自身が「慎重にやる操作」と決めているのは
+        // これだけ。undo もないため CLI からも一手間かける。
+        object RemoveNode(uint id, bool confirm)
         {
-            if (!graphPage.Graph.TryGetNode(new NodeId(id), out _)) return UnknownNode(id);
+            if (!graphPage.Graph.TryGetNode(new NodeId(id), out var node)) return UnknownNode(id);
 
-            graphPage.Graph.RemoveNode(new NodeId(id));
-            graphPage.Sort();
+            if (!confirm)
+                return Failure("confirm_required", $"Removing node {id} ({node.NodeView.Node.Name}) cannot be undone. Pass confirm=true.");
+
+            // HUD と同じ経路を通す。RemoveSelectedNode が選択・ターゲット・State の
+            // 後始末までまとめて行うので、ここで個別に真似すると取りこぼす。
+            graphPage.SelectNode(node);
+            graphPage.RemoveSelectedNode();
             return new { success = true, removed = id };
         }
 
         object SelectNode(uint id)
         {
             if (!graphPage.Graph.TryGetNode(new NodeId(id), out var node)) return UnknownNode(id);
+
+            // HUD はノード選択を NodeSelection / TargetNodeSelection でしか行わない。
+            // 他の State のまま差し替えると SelectedSlot が前のノードのスロットを
+            // 指したままになり、スロット移動が範囲外になる。State ごと戻して揃える。
+            // TODO(#37): State の扱いごと GraphPage 側に寄せる
+            if (graphPage.State.Value != GraphPageState.NodeSelection)
+            {
+                graphPage.SelectSlot(null);
+                graphPage.State.Value = GraphPageState.NodeSelection;
+            }
 
             graphPage.SelectNode(node);
             return new { success = true, selected = id };
@@ -145,14 +163,26 @@ namespace Rector.Cli
             return new { success = true, id };
         }
 
+        // TODO(#37): 検証と接続を GraphPage 側に引き上げ、HUD と同じ実装を呼ぶ。
+        // ここは HUD の TargetSlotSelectionInputHandler.Submit を書き写したもので、
+        // 片方だけ直すと検証がずれる。
         object Connect(uint fromNode, int fromSlot, uint toNode, int toSlot)
         {
             if (!TryGetSlots(fromNode, fromSlot, toNode, toSlot, out var output, out var input, out var error)) return error;
 
+            // HUD は既存エッジをまず外すトグルなので、繋がっている組に TryConnect が
+            // 届くことがない。CLI は connect と disconnect を分けた分この保護がないため
+            // ここで弾く。通すと AddEdge の TryAdd が false になり、購読を持ったまま
+            // どこからも参照されない Edge と EdgeView が残る。
+            if (graphPage.Graph.Edges.ContainsKey(new EdgeId(output, input)))
+                return Failure("already_connected", $"{fromNode}[{fromSlot}] -> {toNode}[{toSlot}] is already connected.");
+
+            if (fromNode == toNode)
+                return Failure("loop_detected", "A node cannot connect to itself.");
+
             if (!EdgeConnector.CanConnect(output, input))
                 return Failure("incompatible_slots", $"{output.Type} -> {input.Type} is not connectable.");
 
-            // UI と同じ検証順。ループを作るとグラフが破綻するので接続前に弾く。
             if (!graphPage.Graph.ValidateLoop(output, input))
                 return Failure("loop_detected", $"Connecting {fromNode} -> {toNode} would create a loop.");
 
@@ -164,6 +194,7 @@ namespace Rector.Cli
             return new { success = true, fromNode, fromSlot, toNode, toSlot };
         }
 
+        // TODO(#37): GraphPage 側に寄せて HUD と共有する
         object Disconnect(uint fromNode, int fromSlot, uint toNode, int toSlot)
         {
             if (!TryGetSlots(fromNode, fromSlot, toNode, toSlot, out var output, out var input, out var error)) return error;

--- a/Assets/Rector/Scripts/Cli/CliClient.cs
+++ b/Assets/Rector/Scripts/Cli/CliClient.cs
@@ -1,0 +1,303 @@
+using System;
+using System.Linq;
+using Rector.Cameras;
+using Rector.UI.GraphPages;
+using Rector.UI.Graphs;
+using Rector.UI.Graphs.Slots;
+using Rector.UI.LayeredGraphDrawing;
+using Rector.Vfx;
+
+namespace Rector.Cli
+{
+    /// <summary>
+    /// Unity CLI (com.unity.pipeline) から Rector を観測・操作するためのファサード。
+    ///
+    /// [CliCommand] は static メソッドしか登録できないが、Rector のシステムは
+    /// RectorInstaller が組み立てるインスタンスとして存在する。そのため
+    /// RectorInstaller が生成したこのクラスを Instance に登録し、コマンドは
+    /// Instance 経由で呼ぶ。
+    ///
+    /// エディタの Play Mode でも Player ビルドでも同じコマンドが使える。
+    /// アプリが動いていない間は Instance が null なので、各コマンドは
+    /// 例外ではなく not_running を返す。
+    /// </summary>
+    public sealed partial class CliClient : IDisposable
+    {
+        public static CliClient Instance { get; private set; }
+
+        public static void Register(CliClient client) => Instance = client;
+
+        readonly GraphPage graphPage;
+        readonly NodeTemplateRepository nodeTemplateRepository;
+        readonly VfxManager vfxManager;
+        readonly CameraManager cameraManager;
+        readonly BGSceneManager bgSceneManager;
+
+        public CliClient(
+            GraphPage graphPage,
+            NodeTemplateRepository nodeTemplateRepository,
+            VfxManager vfxManager,
+            CameraManager cameraManager,
+            BGSceneManager bgSceneManager)
+        {
+            this.graphPage = graphPage;
+            this.nodeTemplateRepository = nodeTemplateRepository;
+            this.vfxManager = vfxManager;
+            this.cameraManager = cameraManager;
+            this.bgSceneManager = bgSceneManager;
+        }
+
+        public void Dispose()
+        {
+            if (ReferenceEquals(Instance, this)) Instance = null;
+        }
+
+        // ---------------------------------------------------------------- 観測
+
+        object GetState() => new
+        {
+            camera = cameraManager.CurrentCamera.CurrentValue,
+            scene = bgSceneManager.CurrentScene.CurrentValue,
+            nodeCount = graphPage.Graph.NodeCount,
+            edgeCount = graphPage.Graph.EdgeCount,
+            selectedNodeId = graphPage.SelectedNode?.Id.Value,
+            pageState = graphPage.State.Value.ToString(),
+        };
+
+        object GetGraph() => new
+        {
+            nodes = Nodes().Select(ToNodeDto).ToArray(),
+            edges = graphPage.Graph.Edges.Keys.Select(id => new
+            {
+                fromNode = id.OutputNodeId.Value,
+                fromSlot = id.OutputSlotIndex,
+                toNode = id.InputNodeId.Value,
+                toSlot = id.InputSlotIndex,
+            }).ToArray(),
+        };
+
+        object GetNodeTemplates() => nodeTemplateRepository.GetAll()
+            .Select(t => new { category = t.Category.ToString(), name = t.Name })
+            .ToArray();
+
+        object GetVfx() => vfxManager.GetAllVfx()
+            .Select(v => new { name = v.Name, category = v.Category.ToString() })
+            .ToArray();
+
+        object GetCameras() => new
+        {
+            current = cameraManager.CurrentCamera.CurrentValue,
+            blendTime = cameraManager.BlendTime.Value,
+            cameras = cameraManager.GetCameraBehaviours()
+                .Select((c, i) => new { index = i, name = c.Name, active = c.IsActive.Value })
+                .ToArray(),
+        };
+
+        object GetScenes() => new
+        {
+            current = bgSceneManager.CurrentScene.CurrentValue,
+            scenes = bgSceneManager.GetScenes(),
+        };
+
+        // ------------------------------------------------------------ グラフ操作
+
+        object CreateNode(string template)
+        {
+            var t = nodeTemplateRepository.GetAll().FirstOrDefault(x => x.Name == template);
+            if (t == null) return Failure("unknown_template", $"No node template named '{template}'.");
+
+            var nodeView = t.Create(NodeId.Generate());
+            graphPage.Graph.AddNode(nodeView);
+            graphPage.Sort();
+            return new { success = true, node = ToNodeDto(nodeView.Node.Id) };
+        }
+
+        object RemoveNode(uint id)
+        {
+            if (!graphPage.Graph.TryGetNode(new NodeId(id), out _)) return UnknownNode(id);
+
+            graphPage.Graph.RemoveNode(new NodeId(id));
+            graphPage.Sort();
+            return new { success = true, removed = id };
+        }
+
+        object SelectNode(uint id)
+        {
+            if (!graphPage.Graph.TryGetNode(new NodeId(id), out var node)) return UnknownNode(id);
+
+            graphPage.SelectNode(node);
+            return new { success = true, selected = id };
+        }
+
+        object SetNodeMuted(uint id, bool muted)
+        {
+            if (!TryGetNode(id, out var node)) return UnknownNode(id);
+
+            node.IsMuted.Value = muted;
+            return new { success = true, id, muted };
+        }
+
+        object InvokeNodeAction(uint id)
+        {
+            if (!TryGetNode(id, out var node)) return UnknownNode(id);
+
+            node.DoAction();
+            return new { success = true, id };
+        }
+
+        object Connect(uint fromNode, int fromSlot, uint toNode, int toSlot)
+        {
+            if (!TryGetSlots(fromNode, fromSlot, toNode, toSlot, out var output, out var input, out var error)) return error;
+
+            if (!EdgeConnector.CanConnect(output, input))
+                return Failure("incompatible_slots", $"{output.Type} -> {input.Type} is not connectable.");
+
+            // UI と同じ検証順。ループを作るとグラフが破綻するので接続前に弾く。
+            if (!graphPage.Graph.ValidateLoop(output, input))
+                return Failure("loop_detected", $"Connecting {fromNode} -> {toNode} would create a loop.");
+
+            if (!EdgeConnector.TryConnect(output, input, out var edge))
+                return Failure("connect_failed", "EdgeConnector refused the connection.");
+
+            graphPage.Graph.AddEdge(edge);
+            graphPage.Sort();
+            return new { success = true, fromNode, fromSlot, toNode, toSlot };
+        }
+
+        object Disconnect(uint fromNode, int fromSlot, uint toNode, int toSlot)
+        {
+            if (!TryGetSlots(fromNode, fromSlot, toNode, toSlot, out var output, out var input, out var error)) return error;
+
+            if (!graphPage.Graph.RemoveEdge(new EdgeId(output, input)))
+                return Failure("no_such_edge", "There is no edge between those slots.");
+
+            graphPage.Sort();
+            return new { success = true, fromNode, fromSlot, toNode, toSlot };
+        }
+
+        object SortGraph()
+        {
+            graphPage.Sort();
+            return new { success = true, nodeCount = graphPage.Graph.NodeCount, edgeCount = graphPage.Graph.EdgeCount };
+        }
+
+        // ------------------------------------------------------ シーン / カメラ / VFX
+
+        object LoadScene(string name)
+        {
+            if (!bgSceneManager.GetScenes().Contains(name))
+                return Failure("unknown_scene", $"No scene named '{name}'.");
+
+            bgSceneManager.Load(name);
+            return new { success = true, scene = name };
+        }
+
+        object SetCamera(int index)
+        {
+            var cameras = cameraManager.GetCameraBehaviours();
+            if (index < 0 || index >= cameras.Length)
+                return Failure("index_out_of_range", $"Camera index must be 0..{cameras.Length - 1}.");
+
+            cameras[index].IsActive.Value = true;
+            return new { success = true, index, name = cameras[index].Name };
+        }
+
+        object ToggleVfx(string name)
+        {
+            var vfx = vfxManager.GetAllVfx().FirstOrDefault(v => v.Name == name);
+            if (vfx == null) return Failure("unknown_vfx", $"No VFX named '{name}'.");
+
+            vfx.ToggleActive();
+            return new { success = true, name };
+        }
+
+        // ---------------------------------------------------------------- 補助
+
+        System.Collections.Generic.IEnumerable<LayeredNode> Nodes() =>
+            graphPage.Graph.Layers.SelectMany(layer => layer).OfType<LayeredNode>();
+
+        bool TryGetNode(uint id, out Rector.UI.Graphs.Nodes.Node node)
+        {
+            if (graphPage.Graph.TryGetNode(new NodeId(id), out var layered))
+            {
+                node = layered.NodeView.Node;
+                return true;
+            }
+
+            node = null;
+            return false;
+        }
+
+        bool TryGetSlots(uint fromNode, int fromSlot, uint toNode, int toSlot,
+            out OutputSlot output, out InputSlot input, out object error)
+        {
+            output = null;
+            input = null;
+
+            if (!TryGetNode(fromNode, out var from))
+            {
+                error = UnknownNode(fromNode);
+                return false;
+            }
+
+            if (!TryGetNode(toNode, out var to))
+            {
+                error = UnknownNode(toNode);
+                return false;
+            }
+
+            if (fromSlot < 0 || fromSlot >= from.OutputSlots.Length)
+            {
+                error = Failure("slot_out_of_range", $"Node {fromNode} has {from.OutputSlots.Length} output slot(s).");
+                return false;
+            }
+
+            if (toSlot < 0 || toSlot >= to.InputSlots.Length)
+            {
+                error = Failure("slot_out_of_range", $"Node {toNode} has {to.InputSlots.Length} input slot(s).");
+                return false;
+            }
+
+            output = from.OutputSlots[fromSlot];
+            input = to.InputSlots[toSlot];
+            error = null;
+            return true;
+        }
+
+        object ToNodeDto(NodeId id) =>
+            graphPage.Graph.TryGetNode(id, out var layered) ? ToNodeDto(layered) : null;
+
+        static object ToNodeDto(LayeredNode layered)
+        {
+            var node = layered.NodeView.Node;
+            return new
+            {
+                id = node.Id.Value,
+                name = node.Name,
+                category = node.Category.ToString(),
+                layer = layered.Layer,
+                muted = node.IsMuted.Value,
+                selected = node.Selected.Value,
+                inputs = node.InputSlots.Select(ToSlotDto).ToArray(),
+                outputs = node.OutputSlots.Select(ToSlotDto).ToArray(),
+            };
+        }
+
+        static object ToSlotDto(ISlot slot) => new
+        {
+            index = slot.Index,
+            name = slot.Name,
+            type = slot.Type.ToString(),
+            connected = slot.ConnectedCount,
+        };
+
+        static object Failure(string code, string message) => new { success = false, error = code, message };
+
+        static object UnknownNode(uint id) => Failure("unknown_node", $"No node with id {id}.");
+
+        static object NotRunning() =>
+            Failure("not_running", "Rector is not running. Enter play mode, or launch a development build.");
+
+        static object Call(Func<CliClient, object> f) => Instance is { } c ? f(c) : NotRunning();
+    }
+}

--- a/Assets/Rector/Scripts/Cli/CliClient.cs.meta
+++ b/Assets/Rector/Scripts/Cli/CliClient.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 87233f5ed4cfb4974af284e5ab59fffe

--- a/Assets/Rector/Scripts/Rector.asmdef
+++ b/Assets/Rector/Scripts/Rector.asmdef
@@ -9,7 +9,8 @@
         "Unity.RenderPipelines.Universal.Runtime",
         "UniTask",
         "R3.Unity",
-        "Lasp.Runtime"
+        "Lasp.Runtime",
+        "Unity.Pipeline"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Assets/Rector/Scripts/RectorInstaller.cs
+++ b/Assets/Rector/Scripts/RectorInstaller.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using Rector.Audio;
 using Rector.Cameras;
+using Rector.Cli;
 using Rector.NodeBehaviours;
 using Rector.UI;
 using Rector.UI.GraphPages;
@@ -87,6 +88,16 @@ namespace Rector
                 cameraManager,
                 hudModel
             ));
+
+            // Unity CLI (com.unity.pipeline) から観測・操作するための口。
+            // [CliCommand] は static しか登録できないので Instance 経由で参照する。
+            CliClient.Register(Register(new CliClient(
+                graphPage,
+                nodeTemplateRepository,
+                vfxManager,
+                cameraManager,
+                bgSceneManager
+            )));
 
 #if !UNITY_EDITOR
             // disable stack trace

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,11 +147,27 @@ unity command eval 'return UnityEditor.AssetDatabase.FindAssets("t:VisualEffectA
 
 ### Driving a build
 
-`unity command --runtime <player exec name>` connects to a running Player the
-same way it connects to the editor, so a development build of Rector can be
-inspected and hot-reloaded while it is actually running against live audio.
-The runtime API is localhost-only and off by default — development and QA
-builds only, never a shipping build.
+`unity command --runtime RectorApp` connects to a running Player, so a build
+processing live audio can be inspected and driven exactly like the editor.
+
+**`--runtime` is an option of `unity command`, so it must come before the
+command name.** Put it after and the call silently goes to the editor instead
+— it does not error, it just answers from the wrong process.
+
+```bash
+unity command --runtime RectorApp rector_state                      # right
+unity command rector_state --runtime RectorApp                      # wrong: hits the editor
+```
+
+`Base.unity` carries a `RuntimePipelineManager` with `enableInBuilds` on, which
+is what starts the server in a Player. It binds IPv4 loopback only and requires
+a bearer token published in `.unity-pipeline-runtime-port` next to the build.
+
+`eval`, `eval_file` and the hot-reload commands are compiled out unless the
+build is a **Development Build** — they sit behind
+`#if UNITY_EDITOR || (UNITY_STANDALONE && DEBUG)`. The server itself and every
+other command, `rector_*` included, carry no such guard. Keep the manager out
+of a shipping build regardless: the command surface can drive the whole graph.
 
 ### Caveats
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,14 @@ Nothing gates the server itself: `RuntimePipelineManager.Start()` checks only
 `EditorUserBuildSettings.development`. A release build from this scene opens
 the port, and `quit` / `set_timescale` / `simulate_key` come with it.
 
+**`enableInBuilds` is deliberately left on** — every build, release included,
+runs the server. Rector is a personal instrument rather than distributed
+software, and being able to drive any build is worth more here than closing a
+port that only processes running as the same user can reach. Reviewers have
+flagged this; it is a decision, not an oversight. Revisit it if Rector is ever
+handed to someone else, and note the exposure is the whole runtime command
+surface, not just `rector_*`.
+
 ### Caveats
 
 - `com.unity.pipeline` is experimental (`0.4.0-exp.1`); its command surface may

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,25 +149,31 @@ unity command eval 'return UnityEditor.AssetDatabase.FindAssets("t:VisualEffectA
 
 `unity command --runtime RectorApp` connects to a running Player, so a build
 processing live audio can be inspected and driven exactly like the editor.
+Placement of `--runtime` does not matter — commander.js claims it wherever it
+appears — but put it before the command name for readability. When no matching
+Player is found the call fails; it never silently answers from the editor.
 
-**`--runtime` is an option of `unity command`, so it must come before the
-command name.** Put it after and the call silently goes to the editor instead
-— it does not error, it just answers from the wrong process.
-
-```bash
-unity command --runtime RectorApp rector_state                      # right
-unity command rector_state --runtime RectorApp                      # wrong: hits the editor
-```
+Watch the shell instead: **zsh does not word-split unquoted parameters**, so
+`FLAGS="--runtime RectorApp"; unity command $FLAGS rector_state` passes one
+argument `--runtime RectorApp`, which is not recognised and the call goes to
+the editor. Write the flags out, or use an array.
 
 `Base.unity` carries a `RuntimePipelineManager` with `enableInBuilds` on, which
-is what starts the server in a Player. It binds IPv4 loopback only and requires
-a bearer token published in `.unity-pipeline-runtime-port` next to the build.
+starts the server in a Player. The listener binds `http://+:<port>/` — every
+interface — and rejects non-loopback callers with 403 in the request handler,
+ahead of the bearer-token check. The token lives in the runtime descriptor,
+which on macOS is written **inside the .app bundle** (`Application.dataPath/..`),
+not beside it.
 
-`eval`, `eval_file` and the hot-reload commands are compiled out unless the
-build is a **Development Build** — they sit behind
-`#if UNITY_EDITOR || (UNITY_STANDALONE && DEBUG)`. The server itself and every
-other command, `rector_*` included, carry no such guard. Keep the manager out
-of a shipping build regardless: the command surface can drive the whole graph.
+Only the Roslyn compilers sit behind
+`#if UNITY_EDITOR || (UNITY_STANDALONE && DEBUG)` — `EvalCodeCompiler`,
+`HotReloadCompiler`, `RoslynCompilationService`. The `eval` and hot-reload
+*commands* stay registered in a release build and return "Platform Not
+Supported". Rector is IL2CPP, so they cannot work in any build regardless.
+Nothing gates the server itself: `RuntimePipelineManager.Start()` checks only
+`autoStart && enableInBuilds`, and the build processor never consults
+`EditorUserBuildSettings.development`. A release build from this scene opens
+the port, and `quit` / `set_timescale` / `simulate_key` come with it.
 
 ### Caveats
 


### PR DESCRIPTION
Adds 17 `rector_*` commands so the CLI can observe and drive Rector itself, not just the editor around it. Total command surface goes 140 → 157.

## The shape

`[CliCommand]` only registers **static** methods, but Rector's systems are instances built by `RectorInstaller`. `CliClient` is a thin facade over those systems:

- `RectorInstaller` constructs it alongside everything else and publishes it as `CliClient.Instance`
- Commands dispatch through `Instance`
- `CliClient : IDisposable` clears `Instance` on teardown, so exiting play mode leaves nothing stale
- When nothing is running, `Instance` is null and commands return a structured `not_running` rather than throwing

The facade stays thin — it projects Rector's own APIs into anonymous objects and does no logic of its own. It lives in two files of one `partial` class (facade in `CliClient.cs`, declarations in `CliClient.Commands.cs`) so neither runs past the 300-line guideline.

## Commands

**Observation** — `rector_state`, `rector_graph`, `rector_node_templates`, `rector_vfx`, `rector_cameras`, `rector_scenes`

**Graph editing** — `rector_create_node`, `rector_remove_node`, `rector_select_node`, `rector_set_node_muted`, `rector_invoke_node`, `rector_connect`, `rector_disconnect`, `rector_sort_graph`

**Scene / camera / VFX** — `rector_load_scene`, `rector_set_camera`, `rector_toggle_vfx`

## Safety

`rector_connect` follows the same validation order the HUD uses in `TargetSlotSelectionInputHandler` — `CanConnect`, then `ValidateLoop`, then `TryConnect`, then `AddEdge` — so a CLI call cannot introduce a cycle the UI would have refused.

Failures return a code plus a message rather than an exception, so a caller can correct itself:

```
{"success":false,"error":"unknown_node","message":"No node with id 99."}
{"success":false,"error":"slot_out_of_range","message":"Node 0 has 5 output slot(s)."}
{"success":false,"error":"loop_detected","message":"Connecting 3 -> 2 would create a loop."}
{"success":false,"error":"unknown_template","message":"No node template named 'NoSuchNode'."}
```

## Verification

Run against a live editor with the terminal focused throughout — no clicking into Unity.

```
$ unity command rector_state
{"camera":"Circle Mid","scene":"Room","nodeCount":0,"edgeCount":0,
 "selectedNodeId":null,"pageState":"NodeSelection"}

$ unity command rector_create_node --template "Beat"
{"success":true,"node":{"id":0,"name":"Beat","category":"Event",...}}

$ unity command rector_create_node --template "Spectrum Ring"
{"success":true,"node":{"id":1,"name":"Spectrum Ring","category":"Vfx",...}}

$ unity command rector_connect --from_node 0 --from_slot 1 --to_node 1 --to_slot 0
{"success":true,"fromNode":0,"fromSlot":1,"toNode":1,"toSlot":0}

$ unity command rector_graph
nodes: id=0 Beat (layer 1), id=1 Spectrum Ring (layer 2)
edges: 0[1] -> 1[0]
```

Loop detection was confirmed by wiring two `Negate` nodes into a cycle; the second connect was refused. Test nodes were removed afterwards and the graph is back to empty.

`Rector` is the runtime assembly, so the same commands are available in a development Player build over `--runtime` — the point being that a build running against live audio can be inspected and driven the same way.

## Also here

`com.unity.test-framework.performance` came in as a `com.unity.pipeline` dependency and writes `PerformanceTestRunInfo.json` / `PerformanceTestRunSettings.json` into `Assets/Resources` on every run. They snapshot the machine and the resolved package set, so they are gitignored.