### PR TITLE
Share graph operations between the HUD and CliClient

### DIFF
--- a/Assets/Rector/Scripts/Cli/CliClient.cs
+++ b/Assets/Rector/Scripts/Cli/CliClient.cs
@@ -124,7 +124,7 @@ namespace Rector.Cli
 
             // HUD と同じ経路を通す。RemoveSelectedNode が選択・ターゲット・State の
             // 後始末までまとめて行うので、ここで個別に真似すると取りこぼす。
-            graphPage.SelectNode(node);
+            graphPage.EnterNodeSelection(node);
             graphPage.RemoveSelectedNode();
             return new { success = true, removed = id };
         }
@@ -134,16 +134,9 @@ namespace Rector.Cli
             if (!graphPage.Graph.TryGetNode(new NodeId(id), out var node)) return UnknownNode(id);
 
             // HUD はノード選択を NodeSelection / TargetNodeSelection でしか行わない。
-            // 他の State のまま差し替えると SelectedSlot が前のノードのスロットを
-            // 指したままになり、スロット移動が範囲外になる。State ごと戻して揃える。
-            // TODO(#37): State の扱いごと GraphPage 側に寄せる
-            if (graphPage.State.Value != GraphPageState.NodeSelection)
-            {
-                graphPage.SelectSlot(null);
-                graphPage.State.Value = GraphPageState.NodeSelection;
-            }
-
-            graphPage.SelectNode(node);
+            // 他の State のまま差し替えると SelectedSlot が前のノードのスロットを指したままに
+            // なるので、State ごと揃える EnterNodeSelection を通す。
+            graphPage.EnterNodeSelection(node);
             return new { success = true, selected = id };
         }
 
@@ -163,46 +156,31 @@ namespace Rector.Cli
             return new { success = true, id };
         }
 
-        // TODO(#37): 検証と接続を GraphPage 側に引き上げ、HUD と同じ実装を呼ぶ。
-        // ここは HUD の TargetSlotSelectionInputHandler.Submit を書き写したもので、
-        // 片方だけ直すと検証がずれる。
+        // HUD は「繋がっていれば外す」トグルなので、繋がっている組に接続処理が届くことがない。
+        // CLI は connect と disconnect を分けているぶんその保護がないが、既接続の判定も
+        // GraphPage 側にあるので、両者で検証がずれることはない。
         object Connect(uint fromNode, int fromSlot, uint toNode, int toSlot)
         {
             if (!TryGetSlots(fromNode, fromSlot, toNode, toSlot, out var output, out var input, out var error)) return error;
 
-            // HUD は既存エッジをまず外すトグルなので、繋がっている組に TryConnect が
-            // 届くことがない。CLI は connect と disconnect を分けた分この保護がないため
-            // ここで弾く。通すと AddEdge の TryAdd が false になり、購読を持ったまま
-            // どこからも参照されない Edge と EdgeView が残る。
-            if (graphPage.Graph.Edges.ContainsKey(new EdgeId(output, input)))
-                return Failure("already_connected", $"{fromNode}[{fromSlot}] -> {toNode}[{toSlot}] is already connected.");
-
-            if (fromNode == toNode)
-                return Failure("loop_detected", "A node cannot connect to itself.");
-
-            if (!EdgeConnector.CanConnect(output, input))
-                return Failure("incompatible_slots", $"{output.Type} -> {input.Type} is not connectable.");
-
-            if (!graphPage.Graph.ValidateLoop(output, input))
-                return Failure("loop_detected", $"Connecting {fromNode} -> {toNode} would create a loop.");
-
-            if (!EdgeConnector.TryConnect(output, input, out var edge))
-                return Failure("connect_failed", "EdgeConnector refused the connection.");
-
-            graphPage.Graph.AddEdge(edge);
-            graphPage.Sort();
-            return new { success = true, fromNode, fromSlot, toNode, toSlot };
+            return graphPage.TryConnectSlots(output, input) switch
+            {
+                ConnectResult.Connected => new { success = true, fromNode, fromSlot, toNode, toSlot },
+                ConnectResult.AlreadyConnected => Failure("already_connected", $"{fromNode}[{fromSlot}] -> {toNode}[{toSlot}] is already connected."),
+                ConnectResult.Loop => Failure("loop_detected", $"Connecting {fromNode} -> {toNode} would create a loop."),
+                ConnectResult.Incompatible => Failure("incompatible_slots", $"{output.Type} -> {input.Type} is not connectable."),
+                ConnectResult.Failed => Failure("connect_failed", "EdgeConnector refused the connection."),
+                _ => throw new ArgumentOutOfRangeException(),
+            };
         }
 
-        // TODO(#37): GraphPage 側に寄せて HUD と共有する
         object Disconnect(uint fromNode, int fromSlot, uint toNode, int toSlot)
         {
             if (!TryGetSlots(fromNode, fromSlot, toNode, toSlot, out var output, out var input, out var error)) return error;
 
-            if (!graphPage.Graph.RemoveEdge(new EdgeId(output, input)))
+            if (!graphPage.DisconnectSlots(output, input))
                 return Failure("no_such_edge", "There is no edge between those slots.");
 
-            graphPage.Sort();
             return new { success = true, fromNode, fromSlot, toNode, toSlot };
         }
 

--- a/Assets/Rector/Scripts/UI/GraphPages/ConnectResult.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/ConnectResult.cs
@@ -1,0 +1,11 @@
+namespace Rector.UI.GraphPages
+{
+    public enum ConnectResult
+    {
+        Connected,
+        AlreadyConnected,
+        Loop,
+        Incompatible,
+        Failed,
+    }
+}

--- a/Assets/Rector/Scripts/UI/GraphPages/ConnectResult.cs.meta
+++ b/Assets/Rector/Scripts/UI/GraphPages/ConnectResult.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a6f3ad307691446efb94941e3aa0d104

--- a/Assets/Rector/Scripts/UI/GraphPages/CreateNodeMenuModel.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/CreateNodeMenuModel.cs
@@ -88,15 +88,31 @@ namespace Rector.UI.GraphPages
             LoadButtons();
             CategoryIndex = 0;
             subIndex = 0;
+            // Hide は Sub の途中でも呼ばれるので、開き直すときに Main へ戻す
+            State.Value = ViewState.Main;
             State.ForceNotify();
             Visible.Value = true;
             CategoryButtons[CategoryIndex].IsFocused.Value = true;
         }
 
+        /// <summary>
+        /// 表示を消すだけ。State は動かさないので GraphPage の State 購読から呼べる。
+        /// </summary>
+        public void Hide()
+        {
+            if (!Visible.Value) return;
+            // LoadButtons 前は空
+            if (CategoryButtons.Count > 0)
+            {
+                CategoryButtons[CategoryIndex].IsFocused.Value = false;
+            }
+
+            Visible.Value = false;
+        }
+
         void Exit()
         {
-            CategoryButtons[CategoryIndex].IsFocused.Value = false;
-            Visible.Value = false;
+            Hide();
             onExit.Invoke();
         }
 

--- a/Assets/Rector/Scripts/UI/GraphPages/GraphPage.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/GraphPage.cs
@@ -111,6 +111,14 @@ namespace Rector.UI.GraphPages
             graphContentTransformer.Initialize();
             graphContentTransformer.AddTo(disposable);
 
+            // 各パネルは自分の Exit 経路でしか閉じないので、State を外（CLI）から動かされると
+            // 出しっぱなしになる。State から閉じる側も張っておく。
+            State.Subscribe(x =>
+            {
+                if (x != GraphPageState.NodeCreation) createNodeMenuModel.Hide();
+                if (x != GraphPageState.NodeParameter) nodeParameterModel.Hide();
+            }).AddTo(disposable);
+
             State.Where(x => x == GraphPageState.NodeCreation)
                 .Subscribe(_ =>
                 {

--- a/Assets/Rector/Scripts/UI/GraphPages/GraphPage.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/GraphPage.cs
@@ -213,6 +213,65 @@ namespace Rector.UI.GraphPages
             TargetSlot = slot;
         }
 
+        /// <summary>
+        /// 選択・ターゲット・State をまとめて NodeSelection に揃える。
+        /// </summary>
+        /// <remarks>
+        /// SelectNode を SetTargetNode より先に呼ぶこと。逆にすると SetTargetNode(null) の
+        /// else 分岐が、これから外す（あるいは削除する）SelectedNode に向けて
+        /// MoveContentToMakeNodeVisible してしまう。
+        /// </remarks>
+        public void EnterNodeSelection(LayeredNode? node)
+        {
+            SelectSlot(null);
+            SelectNode(node);
+            SetTargetSlot(null);
+            SetTargetNode(null);
+            State.Value = GraphPageState.NodeSelection;
+        }
+
+        public bool DisconnectSlots(OutputSlot output, InputSlot input)
+        {
+            if (!Graph.RemoveEdge(new EdgeId(output, input))) return false;
+            Sort();
+            return true;
+        }
+
+        /// <param name="replaceEdgesOn">
+        /// 差し替え接続（HUD で OpenNodeParameter を押しながら繋いだとき）に、
+        /// 先に張られていたエッジを外すスロット。検証を通ったあとに外すので、
+        /// 接続を断られた場合に既存のエッジだけ失うことがない。
+        /// </param>
+        public ConnectResult TryConnectSlots(OutputSlot output, InputSlot input, ISlot? replaceEdgesOn = null)
+        {
+            if (Graph.Edges.ContainsKey(new EdgeId(output, input))) return ConnectResult.AlreadyConnected;
+
+            // ValidateLoop を CanConnect より先に見るのは、自分自身への接続を Incompatible ではなく
+            // Loop として返すため。HUD は TargetNodeSelection で自ノードを選べないので影響しない。
+            if (!Graph.ValidateLoop(output, input))
+            {
+                RectorLogger.LoopDetected(output.NodeId, input.NodeId);
+                return ConnectResult.Loop;
+            }
+
+            if (!EdgeConnector.CanConnect(output, input)) return ConnectResult.Incompatible;
+
+            if (replaceEdgesOn is not null)
+            {
+                Graph.RemoveEdgesFrom(replaceEdgesOn);
+            }
+
+            if (!EdgeConnector.TryConnect(output, input, out var edge))
+            {
+                // replaceEdgesOn の分だけグラフが変わっている可能性がある
+                Sort();
+                return ConnectResult.Failed;
+            }
+
+            Graph.AddEdge(edge);
+            Sort();
+            return ConnectResult.Connected;
+        }
 
         public void ShowHoldNextToSelected()
         {
@@ -230,14 +289,12 @@ namespace Rector.UI.GraphPages
 
         public void RemoveSelectedNode()
         {
-            if (SelectedNode is not null)
-            {
-                Graph.RemoveNode(SelectedNode.Id);
-                SelectSlot(null);
-                SelectNode(null);
-                Sort();
-                State.Value = GraphPageState.NodeSelection;
-            }
+            if (SelectedNode is not { } node) return;
+
+            // NodeView が生きているうちに選択とターゲットを外す
+            EnterNodeSelection(null);
+            Graph.RemoveNode(node.Id);
+            Sort();
         }
 
         public void Sort()

--- a/Assets/Rector/Scripts/UI/GraphPages/NodeParameters/NodeParameterModel.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/NodeParameters/NodeParameterModel.cs
@@ -64,9 +64,18 @@ namespace Rector.UI.GraphPages.NodeParameters
             IsVisible.Value = true;
         }
 
+        /// <summary>
+        /// 表示を消すだけ。State は動かさないので GraphPage の State 購読から呼べる。
+        /// </summary>
+        public void Hide()
+        {
+            if (!IsVisible.Value) return;
+            IsVisible.Value = false;
+        }
+
         public void Close()
         {
-            IsVisible.Value = false;
+            Hide();
             page.State.Value = GraphPageState.NodeSelection;
         }
 

--- a/Assets/Rector/Scripts/UI/GraphPages/TargetSlotSelectionInputHandler.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/TargetSlotSelectionInputHandler.cs
@@ -1,5 +1,4 @@
 using System;
-using Rector.UI.Graphs;
 using Rector.UI.Graphs.Slots;
 using UnityEngine;
 
@@ -48,32 +47,15 @@ namespace Rector.UI.GraphPages
             graphPage.State.Value = GraphPageState.TargetNodeSelection;
         }
 
+        // 繋がっていれば外す、繋がっていなければ繋ぐトグル。検証と接続そのものは GraphPage 側に
+        // あり、CLI も同じものを呼ぶ。
         public override void Submit()
         {
             if (!ToOutputAndInput(graphPage.SelectedSlot, graphPage.TargetSlot, out var output, out var input)) return;
-            var edgeId = new EdgeId(output, input);
-            if (!graphPage.Graph.RemoveEdge(edgeId))
-            {
-                if (!EdgeConnector.CanConnect(output, input)) return;
+            if (graphPage.DisconnectSlots(output, input)) return;
 
-                if (!graphPage.Graph.ValidateLoop(output, input))
-                {
-                    RectorLogger.LoopDetected(output.NodeId, input.NodeId);
-                    return;
-                }
-
-                if (graphPage.IsNodeParameterOpen)
-                {
-                    graphPage.Graph.RemoveEdgesFrom(graphPage.SelectedSlot);
-                }
-
-                if (EdgeConnector.TryConnect(output, input, out var newEdge))
-                {
-                    graphPage.Graph.AddEdge(newEdge);
-                }
-            }
-
-            graphPage.Sort();
+            // OpenNodeParameter を押しながらの接続は、選択中スロットの既存エッジを差し替える
+            graphPage.TryConnectSlots(output, input, graphPage.IsNodeParameterOpen ? graphPage.SelectedSlot : null);
         }
 
         static bool ToOutputAndInput(ISlot slot1, ISlot slot2, out OutputSlot output, out InputSlot input)


### PR DESCRIPTION
Closes #37.

## What changed

`GraphPage` becomes the single operation surface, and both the HUD and `CliClient` compose the same methods instead of one of them remembering what the other does.

**`refactor: share graph operations between the HUD and CliClient`**

- `GraphPage.TryConnectSlots` / `DisconnectSlots` hold the already-connected, loop and type checks, add the edge and re-sort. `ConnectResult` lives in its own file next to `GraphPageState`.
- `TargetSlotSelectionInputHandler.Submit` keeps its toggle by composing the two (28 lines -> 10). `CliClient.Connect` maps `ConnectResult` onto the error codes #36 already shipped, so the JSON contract is unchanged.
- `GraphPage.EnterNodeSelection` resets selection, target and `State` together. `CliClient.SelectNode` / `RemoveNode` go through it, and `RemoveSelectedNode` does too - which also stops it from touching the `NodeView` it has just disposed.
- `Sort()` moved inside the mutating methods: no caller has to remember it, and it no longer runs when nothing changed.
- All three `TODO(#37)` comments are gone.

**`fix: close the graph page overlays when State changes from outside`**

This one is outside the scope #37 names - it is the state machine rather than the operations - but it is the same root cause, so it is here as a separate commit and can be dropped on its own.

The create-node menu and the node parameter panel only hid themselves on their own exit path, which then set `State`. Anything moving `State` directly (`rector_select_node`, `rector_remove_node`) left the panel on screen while input went to the node selection handler. Both models now have a `Hide()` that only touches visibility, and `GraphPage` closes whichever panel does not match the current `State`. `CreateNodeMenuModel.Enter` also resets `ViewState` to `Main`, which `Exit` never needed to do because it was only reachable from `Main`.

## Two deviations from the sketch in the issue

- **The node-parameter replacement runs after validation, not before.** The issue's pseudocode calls `RemoveEdgesFrom` ahead of `TryConnectSlots`, which loses the existing edge whenever the new connection is refused. It is passed in as `replaceEdgesOn` so `GraphPage` enforces the order.
- **`ValidateLoop` is checked before `CanConnect`**, so a self-connect is reported as a loop rather than as incompatible types. The HUD cannot reach that case - `TargetNodeSelection` refuses to target the selected node.

## Verification

Compile is clean (`unity command recompile`, no console errors beyond a pre-existing LASP "no input device"). Driven in play mode through the CLI, with the HUD-side paths invoked directly:

| check | result |
|---|---|
| connect the same pair twice | `already_connected`; 1 edge, `connected` stays 1 (the #36 defect) |
| self-connect / reverse edge / mismatched types | `loop_detected` x2 / `incompatible_slots` |
| disconnect | `connected` returns to 0, so the slot default is restored |
| HUD toggle (`Submit` repeatedly) | connects and disconnects, no duplicate edge |
| invalid connect **with** `replaceEdgesOn` | returns `Incompatible`, edge count 1 -> 1 (existing edge survives) |
| valid connect with `replaceEdgesOn` | replaces: old input 0, new input 1, still 1 edge |
| `rector_select_node` from `TargetSlotSelection` | selection, target and `State` all reset; one node flagged selected |
| `rector_remove_node` on the current target node | no dangling reference; stick input afterwards does not throw |
| CLI call while a panel is open | panel closes; reopening starts at the category list |

No tests were added: the project has no test assembly, and `GraphPage` depends on UXML and the Input System.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4cAXNMgG1YxPJrwEaUjWW