### PR TITLE
Anchor the graph to the top-left instead of the screen center

### DIFF
--- a/Assets/Rector/Scripts/UI/GraphPages/GraphContentTransformer.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/GraphContentTransformer.cs
@@ -23,6 +23,20 @@ namespace Rector.UI.GraphPages
         const float MinScale = 0.5f;
         Vector2 offset;
 
+        /// <summary>Resetでコンテンツを置くときの、maskの端からの余白。</summary>
+        const float ResetMargin = 24f;
+
+        /// <summary>GROUPラベルの高さ。USS (font-size 10px + padding 2px) からの実測値。</summary>
+        const float GroupLabelHeight = 18f;
+
+        /// <summary>
+        /// Resetでコンテンツ原点をmaskのどこに置くか。
+        /// 原点はグループ枠の左上ではなく最上段のノードの左上なので、枠の余白とその上の
+        /// ラベルの分だけ下げないと、mask (overflow: hidden) に切られる。
+        /// </summary>
+        static readonly Vector2 ResetTranslation =
+            new(ResetMargin, ResetMargin + NodeGroups.Padding + GroupLabelHeight);
+
         // resolvedStyle はレイアウト解決後にしか更新されないため、
         // 加減算で読み戻さずに済むよう平行移動量を保持する。
         Vector2 translation;
@@ -84,7 +98,7 @@ namespace Rector.UI.GraphPages
             DisableAnimation();
             currentScale = 1f;
             offset = Vector2.zero;
-            SetTranslation(MaskSizeHalf);
+            SetTranslation(ResetTranslation);
             content.style.scale = Vector3.one;
         }
 


### PR DESCRIPTION
Closes #41

#40 がマージされたので `main` に rebase 済み。差分はコミット1つ・1ファイルだけ。

## なにを変えたか

`GraphContentTransformer.Reset()` が `SetTranslation(MaskSizeHalf)` でコンテンツ原点 — 最初のノードが置かれる場所 — を graph-mask の中央に置いていたのを、左上に寄せた。

これは Follow Focus が常時 ON でグラフが選択のたびに動いていた頃の名残り。当時はどちら向きにパンしても余白がある中央が都合よかったが、#40 でグループが入って Follow Focus の既定が OFF になった今はグラフがその場に留まるので、中央始まりだとビューポートの右下 3/4 が最初から死んでいる。

## マージンの決め方

原点は「GROUP 1 の枠の左上」ではなく「最上段レイヤーのノードの上端」なので、そのまま (0, 0) に置くと枠とラベルが mask の `overflow: hidden` に切られる。原点より上・左にあるものはこれだけ:

| もの | 原点からのオフセット | 出どころ |
|---|---|---|
| グループ枠 上端 | `-NodeGroups.Padding` (-24) | `GraphSorter` が `Place(..., contentTop: 0f, ...)` を呼び、`Place` が `contentTop - Padding` を積む |
| GROUP ラベル 上端 | 枠の上端からさらに -18 | USS `.rector-group-label { bottom: 100% }` |
| グループ枠 左border | 0 | UI Toolkit の border は要素の内側 |

なので `ResetTranslation = (ResetMargin, ResetMargin + NodeGroups.Padding + GroupLabelHeight)` と、由来がわかる式で組んだ。マジックナンバー 1 個だと、あとで `NodeGroups.Padding` や USS を触ったときに直し忘れる。

`GroupLabelHeight = 18f` は目分量ではなく実測値。当初 20 と見積もっていたが、Play Mode で `.rector-group-label` の `resolvedStyle.height` を引いたら 18 だった。

枠の上端は #40 のレビュー対応で全グループ `contentTop = 0f` に揃ったので、`-Padding` は「たまたまそうなる」ではなく確定した値になっている。`ResetBounds()` がコンストラクタで走るようになったため、ノード0個・ソート前の起動直後でも枠は存在し、`SetTranslation` が `GroupGuideView.Layout` を直接呼ぶので枠は content と同じフレームで左上に載る。

## 確認したこと

Play Mode で新しい translation `(24, 66)` を流し込み、mask の左上を原点に測った (7ノード・4グループ):

```
mask (x:55.00, y:141.00, width:1810.00, height:770.00)
GROUP 1 labelTop=24 boxLeft=24   boxTop=42
GROUP 2 labelTop=24 boxLeft=643  boxTop=42
GROUP 3 labelTop=24 boxLeft=883  boxTop=42
GROUP 4 labelTop=24 boxLeft=1123 boxTop=42
node left=48  top=66    node left=48  top=146
node left=176 top=66    node left=48  top=226
node left=48  top=306   node left=428 top=66
node left=556 top=66
```

- 全グループのラベル上端が mask 上端の 24px 下 — 切れていない
- GROUP 1 の枠の左borderが mask 左端の 24px 右 — 切れていない
- 最初のノードが (48, 66) = マージン 24 + グループ内側の余白 24
- ノードは枠の内側 (枠上端 42 に対しノード上端 66、差は `Padding` の 24)

HUD は UI Toolkit のオーバーレイなので `capture_game_view` にも `screenshot` にも映らない。スクショの代わりに数値で押さえた。

## 触らなかったもの

- `MoveContentToMakeNodeVisible()` / `offset` — Follow Focus ON 時の中央寄せは現状維持。「名前に反して毎回中央へ持ってくる」のは #40 の既知課題のまま残す
- `ApplyZoom()` — `worldBound` 基準なので原点が動いても影響しない
- `GroupGuideView` — `translation` を丸ごと受け取るので自動で追随する
- USS / UXML

`MaskSizeHalf` は `MoveContentToMakeNodeVisible()` がまだ使うので残してある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)