### PR TITLE
Focus the Group row when the node parameter panel opens

### DIFF
--- a/Assets/Rector/Scripts/UI/GraphPages/NodeParameters/NodeParameterModel.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/NodeParameters/NodeParameterModel.cs
@@ -54,14 +54,10 @@ namespace Rector.UI.GraphPages.NodeParameters
                 }
             }
 
-            // 先頭はGroup行なので、パラメータを持つノードでは2番目から始める。
-            // ここを0のままにすると、開いて最初の十字キー左右がノードのグループ移動になってしまう。
-            index = ExposedInputs.Count switch
-            {
-                0 => -1,
-                1 => 0,
-                _ => 1
-            };
+            // 先頭のGroup行にフォーカスを置く。開いてすぐ左右でグループを振り分けられるのが狙いで、
+            // 「開いて最初の十字キー左右がグループ移動になる」のは避けたい副作用ではなく意図した
+            // 挙動 (#43)。ノードが選ばれていればGroup行は必ずあるので、-1になるのは未選択のときだけ。
+            index = ExposedInputs.Count > 0 ? 0 : -1;
             if (index >= 0) ExposedInputs[index].Focus();
 
             IsVisible.Value = true;


### PR DESCRIPTION
Closes #43

パラメータパネルを開いたとき、2行目（最初の入力スロット）にフォーカスが当たっていたのを、先頭の Group 行に戻した。

## なぜ2行目になっていたか

#40 のレビュー対応 (`b9864bd`) で入れた。指摘は「Group 行を先頭に足したのに初期フォーカスが 0 のままで、開いて最初の十字キー左右がノードのグループ移動になっていた」で、それを避けるために `ExposedInputs.Count` で分岐して 2 行目から始めるようにしていた。

これは設計意図の取り違えだった。**開いてすぐ左右でグループを振り分けられるのが Group 行を先頭に置いた理由**で、「最初の左右がグループ移動になる」のは避けたい副作用ではなく狙った挙動。スキップした結果、グループを動かすたびに毎回まず上キーを1回挟む操作になっていた。

## 変更

```diff
-            // 先頭はGroup行なので、パラメータを持つノードでは2番目から始める。
-            // ここを0のままにすると、開いて最初の十字キー左右がノードのグループ移動になってしまう。
-            index = ExposedInputs.Count switch
-            {
-                0 => -1,
-                1 => 0,
-                _ => 1
-            };
+            // 先頭のGroup行にフォーカスを置く。開いてすぐ左右でグループを振り分けられるのが狙いで、
+            // 「開いて最初の十字キー左右がグループ移動になる」のは避けたい副作用ではなく意図した
+            // 挙動 (#43)。ノードが選ばれていればGroup行は必ずあるので、-1になるのは未選択のときだけ。
+            index = ExposedInputs.Count > 0 ? 0 : -1;
             if (index >= 0) ExposedInputs[index].Focus();
```

理由をコメントに残したのは、書かずに戻すと次のレビューで同じ指摘がまた通ってしまうため。CLAUDE.md の `enableInBuilds` と同じ扱いにした。

3分岐の `switch` は2値で足りるので三項に畳んだ。`ExposedInputs` はノードが選ばれていれば必ず Group 行を含むので `Count == 0` はノード未選択のときだけで、`Navigate` / `Increment` / `Decrement` / `DoAction` の頭にある `if (index == -1) return;` の番人はそのまま効く。

`ExposedGroupInputModel` / `NodeParameterView` / `NodeParameterInputHandler` は触っていない。

## 確認

- Unity 同梱 Roslyn でコンパイル確認（エディタが別 worktree を開いているため `unity command recompile` は使えない）
- 動作はシバヅケが手元で確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)