### PR TITLE
change: adjust node group layout spacing and top alignment

### DIFF
--- a/Assets/Rector/Scripts/UI/LayeredGraphDrawing/GraphSorter.cs
+++ b/Assets/Rector/Scripts/UI/LayeredGraphDrawing/GraphSorter.cs
@@ -107,25 +107,28 @@ namespace Rector.UI.LayeredGraphDrawing
 
                 var minX = 0f;
                 var contentWidth = 0f;
+                var contentTop = 0f;
                 var contentBottom = 0f;
                 if (colNodes.Count > 0)
                 {
                     minX = float.MaxValue;
                     var maxX = float.MinValue;
+                    contentTop = float.MaxValue;
                     foreach (var node in colNodes.Values)
                     {
                         var nodeX = x[node.Id];
                         minX = Mathf.Min(minX, nodeX);
                         maxX = Mathf.Max(maxX, nodeX + Resolved(node, node.Width, ref hasUnresolvedWidth));
+                        contentTop = Mathf.Min(contentTop, layerY[node.Layer]);
                         contentBottom = Mathf.Max(contentBottom, layerY[node.Layer] + Resolved(node, node.Height, ref hasUnresolvedWidth));
                     }
 
                     contentWidth = maxX - minX;
                 }
 
-                // 枠の上端は全グループで揃える。グループごとの一番上のノードに合わせると、
-                // 他グループからのエッジでしか繋がらないグループのヘッダーだけ下がってしまう。
-                var width = groups.Place(originX, contentWidth, 0f, contentBottom);
+                // 枠の上端はグループ内の一番上のノード(dummy含む)に合わせる。他グループからの
+                // エッジでしか繋がらないグループはヘッダーごと下がるが、それが意図した見た目 (#47)。
+                var width = groups.Place(originX, contentWidth, contentTop, contentBottom - contentTop);
 
                 foreach (var node in colNodes.Values)
                 {
@@ -133,8 +136,7 @@ namespace Rector.UI.LayeredGraphDrawing
                     if (node.IsDummy) dummyNodeCount++;
                 }
 
-                // グループ同士は隙間なく並べる。区切りは左borderと内側のPaddingで付ける。
-                originX += width;
+                originX += width + NodeGroups.Gap;
                 type1ConflictCount += markedEdges.Count;
             }
 

--- a/Assets/Rector/Scripts/UI/LayeredGraphDrawing/NodeGroups.cs
+++ b/Assets/Rector/Scripts/UI/LayeredGraphDrawing/NodeGroups.cs
@@ -41,8 +41,14 @@ namespace Rector.UI.LayeredGraphDrawing
         /// <summary>グループの最小幅。NodeView.Widthはレイアウト解決前は0なので、その揺れもここで吸収される。</summary>
         public const float MinWidth = 240f;
 
-        /// <summary>グループの左右の内側の余白。左borderとノードがくっついて見えなくなるのを防ぐ。</summary>
+        /// <summary>グループの左右と上の内側の余白。左borderとノードがくっついて見えなくなるのを防ぐ。</summary>
         public const float Padding = 24f;
+
+        /// <summary>グループの下側の内側の余白。ノードが1行だけのとき枠がぺちゃんこに見えないよう、他の辺より広い。</summary>
+        public const float BottomPadding = 48f;
+
+        /// <summary>グループ同士の横の隙間。</summary>
+        public const float Gap = 8f;
 
         const string PrefsKey = "Rector_NodeGroupCount";
 
@@ -89,7 +95,7 @@ namespace Rector.UI.LayeredGraphDrawing
             bounds.Clear();
             for (var i = 0; i < count.Value; i++)
             {
-                bounds.Add(new GroupBounds(i * MinWidth, MinWidth, -Padding, Padding * 2f));
+                bounds.Add(new GroupBounds(i * (MinWidth + Gap), MinWidth, -Padding, Padding + BottomPadding));
             }
 
             Revision++;
@@ -125,7 +131,7 @@ namespace Rector.UI.LayeredGraphDrawing
         public float Place(float originX, float contentWidth, float contentTop, float contentHeight)
         {
             var width = Mathf.Max(MinWidth, contentWidth + Padding * 2f);
-            bounds.Add(new GroupBounds(originX, width, contentTop - Padding, contentHeight + Padding * 2f));
+            bounds.Add(new GroupBounds(originX, width, contentTop - Padding, contentHeight + Padding + BottomPadding));
             return width;
         }
     }


### PR DESCRIPTION
Closes #47

## 変更内容

node group（カンバン風の縦割り）の見た目調整。

- **group枠の下余白を拡大**: `NodeGroups.BottomPadding = 48f` を新設（上・左右は従来どおり `Padding = 24f`）。ノードが横一列だけのとき枠がぺちゃんこに見えるのを解消
- **group間に横の隙間**: `NodeGroups.Gap = 8f` を新設し、`GraphSorter` で `originX += width + Gap` に変更（従来は意図的に隙間ゼロ）
- **group上端をノードに揃える**: `contentTop`（グループ内ノードの最上端、group内dummy node含む）を集計して `NodeGroups.Place()` に渡すように変更。従来は `0f` ハードコードで全グループの上端を強制的に揃えていた
  - これにより group1 のノードの子が group2 にあるとき、group2 の枠がヘッダーごと下に降りる

## 補足

- 余白・隙間の値は初期値。見た目次第で定数1行で調整可能
- `GraphContentTransformer.ResetTranslation` は「最上段ノードの上に Padding + ラベル」前提だが、layer 0 はノードがある限り必ず埋まるため前提は維持される
- `.rector-group` は USS で `top` の transition を持つため、上端の移動もアニメーションする

## 検証

- Unity 同梱 Roslyn での直接コンパイルでエラーなし（worktree 作業のためエディタの recompile は不使用）
- `dotnet format` 実行済み（差分なし）
- 実機での見た目確認は未実施（エディタをこのブランチへ向けて確認する）

🤖 Generated with [Claude Code](https://claude.com/claude-code)