### PR TITLE
change: rework controller input into a modifier grammar

### DIFF
--- a/Assets/Rector/Scripts/RectorInput.cs
+++ b/Assets/Rector/Scripts/RectorInput.cs
@@ -246,7 +246,7 @@ namespace Rector
                 },
                 {
                     ""name"": ""Zoom"",
-                    ""type"": ""PassThrough"",
+                    ""type"": ""Value"",
                     ""id"": ""5eb0c98f-5742-4243-8bc9-2687be779826"",
                     ""expectedControlType"": ""Axis"",
                     ""processors"": """",

--- a/Assets/Rector/Scripts/RectorInput.cs
+++ b/Assets/Rector/Scripts/RectorInput.cs
@@ -576,7 +576,7 @@ namespace Rector
                 {
                     ""name"": """",
                     ""id"": ""20f8af16-4d2c-48ef-9662-510ea1664d47"",
-                    ""path"": ""<Gamepad>/leftTrigger"",
+                    ""path"": ""<Gamepad>/rightTrigger"",
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
@@ -598,7 +598,7 @@ namespace Rector
                 {
                     ""name"": """",
                     ""id"": ""09136dca-c62b-46b9-a3e7-55cd9bb3cb68"",
-                    ""path"": ""<Gamepad>/rightTrigger"",
+                    ""path"": ""<Gamepad>/leftTrigger"",
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",

--- a/Assets/Rector/Scripts/RectorInput.cs
+++ b/Assets/Rector/Scripts/RectorInput.cs
@@ -175,9 +175,29 @@ namespace Rector
                     ""priority"": 0
                 },
                 {
-                    ""name"": ""NodeModifier"",
+                    ""name"": ""NavModifier"",
                     ""type"": ""Button"",
                     ""id"": ""80adc06a-a353-4f9f-ba4e-33bf59dcefaa"",
+                    ""expectedControlType"": """",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": true,
+                    ""priority"": 0
+                },
+                {
+                    ""name"": ""GrabModifier"",
+                    ""type"": ""Button"",
+                    ""id"": ""42602014-d6ee-4fa8-be7f-5de191d1a6db"",
+                    ""expectedControlType"": """",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": true,
+                    ""priority"": 0
+                },
+                {
+                    ""name"": ""Lock"",
+                    ""type"": ""Button"",
+                    ""id"": ""6f985f69-b9b2-4366-b0de-50373d77decf"",
                     ""expectedControlType"": """",
                     ""processors"": """",
                     ""interactions"": """",
@@ -538,7 +558,7 @@ namespace Rector
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""NodeModifier"",
+                    ""action"": ""NavModifier"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
                 },
@@ -549,7 +569,51 @@ namespace Rector
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""NodeModifier"",
+                    ""action"": ""NavModifier"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""20f8af16-4d2c-48ef-9662-510ea1664d47"",
+                    ""path"": ""<Gamepad>/leftTrigger"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""GrabModifier"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""46485fac-71ff-461e-a308-773847cfc799"",
+                    ""path"": ""<Keyboard>/ctrl"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""GrabModifier"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""09136dca-c62b-46b9-a3e7-55cd9bb3cb68"",
+                    ""path"": ""<Gamepad>/rightTrigger"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Lock"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""112e2868-bd45-4429-b6d9-1fe7bba76690"",
+                    ""path"": ""<Keyboard>/tab"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Lock"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
                 },
@@ -631,37 +695,15 @@ namespace Rector
                     ""isPartOfComposite"": false
                 },
                 {
-                    ""name"": ""1D Axis"",
-                    ""id"": ""2f61fea0-52df-4807-88a3-6a4563eceabe"",
-                    ""path"": ""1DAxis"",
+                    ""name"": """",
+                    ""id"": ""455117e2-4359-4c37-9607-d91a5845056e"",
+                    ""path"": ""<Gamepad>/leftStick/y"",
                     ""interactions"": """",
-                    ""processors"": """",
+                    ""processors"": ""AxisDeadzone"",
                     ""groups"": """",
                     ""action"": ""Zoom"",
-                    ""isComposite"": true,
+                    ""isComposite"": false,
                     ""isPartOfComposite"": false
-                },
-                {
-                    ""name"": ""negative"",
-                    ""id"": ""3145a9a5-5238-4a09-9491-f1fc4623144d"",
-                    ""path"": ""<Gamepad>/leftTrigger"",
-                    ""interactions"": """",
-                    ""processors"": """",
-                    ""groups"": """",
-                    ""action"": ""Zoom"",
-                    ""isComposite"": false,
-                    ""isPartOfComposite"": true
-                },
-                {
-                    ""name"": ""positive"",
-                    ""id"": ""d0a1707e-9f53-43b9-9bdf-a547ff1cc284"",
-                    ""path"": ""<Gamepad>/rightTrigger"",
-                    ""interactions"": """",
-                    ""processors"": """",
-                    ""groups"": """",
-                    ""action"": ""Zoom"",
-                    ""isComposite"": false,
-                    ""isPartOfComposite"": true
                 },
                 {
                     ""name"": ""1D Axis"",
@@ -781,17 +823,6 @@ namespace Rector
                     ""processors"": """",
                     ""groups"": """",
                     ""action"": ""ResetTransform"",
-                    ""isComposite"": false,
-                    ""isPartOfComposite"": false
-                },
-                {
-                    ""name"": """",
-                    ""id"": ""ea5931e7-cf5d-4aec-bae9-65d4c42466fd"",
-                    ""path"": ""<Gamepad>/leftStick"",
-                    ""interactions"": """",
-                    ""processors"": """",
-                    ""groups"": "";Gamepad"",
-                    ""action"": ""MoveGroup"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
                 },
@@ -1217,7 +1248,9 @@ namespace Rector
             m_Graph_AddNode = m_Graph.FindAction("AddNode", throwIfNotFound: true);
             m_Graph_RemoveEdge = m_Graph.FindAction("RemoveEdge", throwIfNotFound: true);
             m_Graph_RemoveNode = m_Graph.FindAction("RemoveNode", throwIfNotFound: true);
-            m_Graph_NodeModifier = m_Graph.FindAction("NodeModifier", throwIfNotFound: true);
+            m_Graph_NavModifier = m_Graph.FindAction("NavModifier", throwIfNotFound: true);
+            m_Graph_GrabModifier = m_Graph.FindAction("GrabModifier", throwIfNotFound: true);
+            m_Graph_Lock = m_Graph.FindAction("Lock", throwIfNotFound: true);
             m_Graph_Mute = m_Graph.FindAction("Mute", throwIfNotFound: true);
             m_Graph_OpenNodeParameter = m_Graph.FindAction("OpenNodeParameter", throwIfNotFound: true);
             m_Graph_OpenSystem = m_Graph.FindAction("OpenSystem", throwIfNotFound: true);
@@ -1324,7 +1357,9 @@ namespace Rector
         private readonly InputAction m_Graph_AddNode;
         private readonly InputAction m_Graph_RemoveEdge;
         private readonly InputAction m_Graph_RemoveNode;
-        private readonly InputAction m_Graph_NodeModifier;
+        private readonly InputAction m_Graph_NavModifier;
+        private readonly InputAction m_Graph_GrabModifier;
+        private readonly InputAction m_Graph_Lock;
         private readonly InputAction m_Graph_Mute;
         private readonly InputAction m_Graph_OpenNodeParameter;
         private readonly InputAction m_Graph_OpenSystem;
@@ -1376,9 +1411,17 @@ namespace Rector
             /// </summary>
             public InputAction @RemoveNode => m_Wrapper.m_Graph_RemoveNode;
             /// <summary>
-            /// Provides access to the underlying input action "Graph/NodeModifier".
+            /// Provides access to the underlying input action "Graph/NavModifier".
             /// </summary>
-            public InputAction @NodeModifier => m_Wrapper.m_Graph_NodeModifier;
+            public InputAction @NavModifier => m_Wrapper.m_Graph_NavModifier;
+            /// <summary>
+            /// Provides access to the underlying input action "Graph/GrabModifier".
+            /// </summary>
+            public InputAction @GrabModifier => m_Wrapper.m_Graph_GrabModifier;
+            /// <summary>
+            /// Provides access to the underlying input action "Graph/Lock".
+            /// </summary>
+            public InputAction @Lock => m_Wrapper.m_Graph_Lock;
             /// <summary>
             /// Provides access to the underlying input action "Graph/Mute".
             /// </summary>
@@ -1457,9 +1500,15 @@ namespace Rector
                 @RemoveNode.started += instance.OnRemoveNode;
                 @RemoveNode.performed += instance.OnRemoveNode;
                 @RemoveNode.canceled += instance.OnRemoveNode;
-                @NodeModifier.started += instance.OnNodeModifier;
-                @NodeModifier.performed += instance.OnNodeModifier;
-                @NodeModifier.canceled += instance.OnNodeModifier;
+                @NavModifier.started += instance.OnNavModifier;
+                @NavModifier.performed += instance.OnNavModifier;
+                @NavModifier.canceled += instance.OnNavModifier;
+                @GrabModifier.started += instance.OnGrabModifier;
+                @GrabModifier.performed += instance.OnGrabModifier;
+                @GrabModifier.canceled += instance.OnGrabModifier;
+                @Lock.started += instance.OnLock;
+                @Lock.performed += instance.OnLock;
+                @Lock.canceled += instance.OnLock;
                 @Mute.started += instance.OnMute;
                 @Mute.performed += instance.OnMute;
                 @Mute.canceled += instance.OnMute;
@@ -1516,9 +1565,15 @@ namespace Rector
                 @RemoveNode.started -= instance.OnRemoveNode;
                 @RemoveNode.performed -= instance.OnRemoveNode;
                 @RemoveNode.canceled -= instance.OnRemoveNode;
-                @NodeModifier.started -= instance.OnNodeModifier;
-                @NodeModifier.performed -= instance.OnNodeModifier;
-                @NodeModifier.canceled -= instance.OnNodeModifier;
+                @NavModifier.started -= instance.OnNavModifier;
+                @NavModifier.performed -= instance.OnNavModifier;
+                @NavModifier.canceled -= instance.OnNavModifier;
+                @GrabModifier.started -= instance.OnGrabModifier;
+                @GrabModifier.performed -= instance.OnGrabModifier;
+                @GrabModifier.canceled -= instance.OnGrabModifier;
+                @Lock.started -= instance.OnLock;
+                @Lock.performed -= instance.OnLock;
+                @Lock.canceled -= instance.OnLock;
                 @Mute.started -= instance.OnMute;
                 @Mute.performed -= instance.OnMute;
                 @Mute.canceled -= instance.OnMute;
@@ -1810,12 +1865,26 @@ namespace Rector
             /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
             void OnRemoveNode(InputAction.CallbackContext context);
             /// <summary>
-            /// Method invoked when associated input action "NodeModifier" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// Method invoked when associated input action "NavModifier" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
             /// </summary>
             /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
             /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
             /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
-            void OnNodeModifier(InputAction.CallbackContext context);
+            void OnNavModifier(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "GrabModifier" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnGrabModifier(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "Lock" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnLock(InputAction.CallbackContext context);
             /// <summary>
             /// Method invoked when associated input action "Mute" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
             /// </summary>

--- a/Assets/Rector/Scripts/UI/GraphPages/GraphContentTransformer.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/GraphContentTransformer.cs
@@ -156,7 +156,7 @@ namespace Rector.UI.GraphPages
 
         public void MoveContentToMakeNodeVisible(LayeredNode node)
         {
-            // 常時追従の設定に加えて、Lock(R2/Tab)を握っている間だけの一時追従がある
+            // 常時追従の設定に加えて、Lock(L2/Tab)を握っている間だけの一時追従がある
             if (!viewSettings.FollowSelectedNode.CurrentValue && !graphInputAction.IsLockHeld) return;
 
             // left-top

--- a/Assets/Rector/Scripts/UI/GraphPages/GraphContentTransformer.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/GraphContentTransformer.cs
@@ -105,7 +105,8 @@ namespace Rector.UI.GraphPages
         void ApplyZoom(float zoom)
         {
             var beforeScale = currentScale;
-            var delta = Time.deltaTime * Mathf.Sign(zoom);
+            // スティックの倒し量(±1)がそのまま速度になる。キーボード(U/O)は±1で従来速度。
+            var delta = Time.deltaTime * zoom;
             currentScale = Mathf.Clamp(currentScale + delta, MinScale, MaxScale);
             var scale = new Vector3(currentScale, currentScale, 1f);
             content.style.scale = scale;
@@ -155,7 +156,8 @@ namespace Rector.UI.GraphPages
 
         public void MoveContentToMakeNodeVisible(LayeredNode node)
         {
-            if (!viewSettings.FollowSelectedNode.CurrentValue) return;
+            // 常時追従の設定に加えて、Lock(R2/Tab)を握っている間だけの一時追従がある
+            if (!viewSettings.FollowSelectedNode.CurrentValue && !graphInputAction.IsLockHeld) return;
 
             // left-top
             var nodePosition = node.TargetPosition * currentScale;

--- a/Assets/Rector/Scripts/UI/GraphPages/GraphInputAction.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/GraphInputAction.cs
@@ -23,6 +23,9 @@ namespace Rector.UI.GraphPages
         readonly Subject<HoldState> removeEdge = new();
         readonly Subject<HoldState> removeNode = new();
         readonly Subject<Unit> mute = new();
+        readonly Subject<Unit> muteChord = new();
+        readonly Subject<Vector2Int> navigateInGroup = new();
+        readonly Subject<Unit> lockStarted = new();
         readonly Subject<Unit> openNodeParameter = new();
         readonly Subject<Unit> closeNodeParameter = new();
         readonly Subject<Unit> openSystem = new();
@@ -40,6 +43,9 @@ namespace Rector.UI.GraphPages
         public Observable<HoldState> RemoveEdge => removeEdge;
         public Observable<HoldState> RemoveNode => removeNode;
         public Observable<Unit> Mute => mute;
+        public Observable<Unit> MuteChord => muteChord;
+        public Observable<Vector2Int> NavigateInGroup => navigateInGroup;
+        public Observable<Unit> LockStarted => lockStarted;
         public Observable<Unit> OpenNodeParameter => openNodeParameter;
         public Observable<Unit> CloseNodeParameter => closeNodeParameter;
         public Observable<Unit> OpenSystem => openSystem;
@@ -52,6 +58,7 @@ namespace Rector.UI.GraphPages
         public Vector2 Translate { get; private set; }
         public float Zoom { get; private set; }
         public bool IsNodeParameterOpen => rectorInput.Graph.OpenNodeParameter.IsPressed();
+        public bool IsLockHeld => rectorInput.Graph.Lock.IsPressed();
 
         const float DirectionThreshold = 0.5f;
         int moveGroupDirection;
@@ -65,8 +72,10 @@ namespace Rector.UI.GraphPages
             Right,
         }
 
-        bool nodeModifierHeld;
-        NavigateDirection nodeModifierNavigateDirection;
+        bool navModifierHeld;
+        bool grabModifierHeld;
+        NavigateDirection chordNavigateDirection;
+        bool nodeParameterOpenSuppressed;
 
         bool removeNodeHolding;
         int removeNodeHoldId;
@@ -87,6 +96,7 @@ namespace Rector.UI.GraphPages
         {
             Translate = Vector2.zero;
             Zoom = 0f;
+            nodeParameterOpenSuppressed = false;
             // moveGroupDirection はここでリセットしない。MoveGroup は initialStateCheck 付きなので、
             // 倒したまま抜けて戻ると再有効化時に performed が来る。0に戻しておくと
             // 「中立から倒れた」と誤判定して、触っていないのにグループが1つ飛ぶ。
@@ -107,9 +117,9 @@ namespace Rector.UI.GraphPages
 
         void HandleNavigate(Vector2 value)
         {
-            if (nodeModifierHeld)
+            if (navModifierHeld || grabModifierHeld)
             {
-                HandleNodeModifierNavigate(value);
+                HandleChordNavigate(value);
                 return;
             }
 
@@ -117,30 +127,49 @@ namespace Rector.UI.GraphPages
         }
 
         /// <remarks>
-        /// NodeModifier(L1/Option)を押している間は十字キーを別コマンドとして扱う。
-        /// 左右は選択ノードのグループ移動、下はミュートのトグル。
-        /// どちらも離散的な操作なのでリピートさせず、方向が新しく確定した瞬間だけ発火させる。
+        /// 修飾キーを押している間は十字キーを別コマンドとして扱う。
+        /// NavModifier(L1/Option): 上下左右ともグループ内に閉じたフォーカス移動。
+        /// GrabModifier(L2/Ctrl): 左右は選択ノードのグループ移動。両方押しはGrab優先。
+        /// どれも離散的な操作なのでリピートさせず、方向が新しく確定した瞬間だけ発火させる。
         /// </remarks>
-        void HandleNodeModifierNavigate(Vector2 value)
+        void HandleChordNavigate(Vector2 value)
         {
             // 斜めは判定保留(前の方向を維持)。Noneに落とすと、右→右下→右と転がっただけで
-            // 「倒し直した」ことになりグループ移動が二重発火する。逆に縦横どちらかに寄せると、
-            // 右を押した指が角に転がった瞬間にミュートが誤発火する。
+            // 「倒し直した」ことになりグループ内移動が二重発火する。逆に縦横どちらかに寄せると、
+            // 右を押した指が角に転がった瞬間に別コマンドが誤発火する。
             var direction = ToNavigateDirection(value);
-            if (direction is not { } d || d == nodeModifierNavigateDirection) return;
+            if (direction is not { } d || d == chordNavigateDirection) return;
 
-            nodeModifierNavigateDirection = d;
-            switch (d)
+            chordNavigateDirection = d;
+            if (grabModifierHeld)
             {
-                case NavigateDirection.Left:
-                    moveNodeToGroup.OnNext(-1);
-                    break;
-                case NavigateDirection.Right:
-                    moveNodeToGroup.OnNext(1);
-                    break;
-                case NavigateDirection.Down:
-                    mute.OnNext(Unit.Default);
-                    break;
+                switch (d)
+                {
+                    case NavigateDirection.Left:
+                        moveNodeToGroup.OnNext(-1);
+                        break;
+                    case NavigateDirection.Right:
+                        moveNodeToGroup.OnNext(1);
+                        break;
+                }
+            }
+            else
+            {
+                switch (d)
+                {
+                    case NavigateDirection.Left:
+                        navigateInGroup.OnNext(new Vector2Int(-1, 0));
+                        break;
+                    case NavigateDirection.Right:
+                        navigateInGroup.OnNext(new Vector2Int(1, 0));
+                        break;
+                    case NavigateDirection.Up:
+                        navigateInGroup.OnNext(new Vector2Int(0, 1));
+                        break;
+                    case NavigateDirection.Down:
+                        navigateInGroup.OnNext(new Vector2Int(0, -1));
+                        break;
+                }
             }
         }
 
@@ -283,30 +312,54 @@ namespace Rector.UI.GraphPages
         }
 
         /// <remarks>
-        /// NodeModifierは単押しでは何もしない修飾キー。押している間の十字キーを
-        /// <see cref="HandleNodeModifierNavigate"/> が拾う。
+        /// NavModifierは単押しでは何もしない修飾キー。押している間の十字キーを
+        /// <see cref="HandleChordNavigate"/> が拾う。OpenNodeParameter(R1/Shift)と
+        /// 重ねるとミュートトグルになる(押し順非依存)。
         /// initialStateCheck付きなので、押したままページを出入りしても再有効化時に
         /// performedが来て修飾キー状態が復元される。
         /// </remarks>
-        public void OnNodeModifier(InputAction.CallbackContext context)
+        public void OnNavModifier(InputAction.CallbackContext context)
         {
             if (context.performed)
             {
-                nodeModifierHeld = true;
-                // 押した時点で既に倒れている十字キーは発火させない。倒し直しを待つ。
-                nodeModifierNavigateDirection = ToNavigateDirection(rectorInput.Graph.Navigate.ReadValue<Vector2>()) ?? NavigateDirection.None;
-                // リピート中のナビゲートも止める
-                navigateInputThrottle.SetInput(Vector2.zero);
+                navModifierHeld = true;
+                BeginChord();
+                // パネルを開いている指に後から重ねた場合もミュートにする
+                if (rectorInput.Graph.OpenNodeParameter.IsPressed())
+                {
+                    muteChord.OnNext(Unit.Default);
+                }
             }
             else if (context.canceled)
             {
                 // 離した時点で倒れたままの十字キーはナビゲートに引き継がない。
                 // Navigateは値が変わるまでイベントが来ないので、倒し直すまで移動しない。
-                nodeModifierHeld = false;
+                navModifierHeld = false;
             }
         }
 
-        /// <remarks>キーボード(V)専用の単押しトグル。ゲームパッドはNodeModifier+下で同じ操作。</remarks>
+        public void OnGrabModifier(InputAction.CallbackContext context)
+        {
+            if (context.performed)
+            {
+                grabModifierHeld = true;
+                BeginChord();
+            }
+            else if (context.canceled)
+            {
+                grabModifierHeld = false;
+            }
+        }
+
+        void BeginChord()
+        {
+            // 押した時点で既に倒れている十字キーは発火させない。倒し直しを待つ。
+            chordNavigateDirection = ToNavigateDirection(rectorInput.Graph.Navigate.ReadValue<Vector2>()) ?? NavigateDirection.None;
+            // リピート中のナビゲートも止める
+            navigateInputThrottle.SetInput(Vector2.zero);
+        }
+
+        /// <remarks>キーボード(V)専用の単押しトグル。ゲームパッドはL1+R1(MuteChord)で同じ操作。</remarks>
         public void OnMute(InputAction.CallbackContext context)
         {
             if (context.performed)
@@ -319,11 +372,34 @@ namespace Rector.UI.GraphPages
         {
             if (context.performed)
             {
+                // NavModifier(L1/Option)を押しながらのときはミュートトグルで、パネルは開かない
+                if (navModifierHeld)
+                {
+                    nodeParameterOpenSuppressed = true;
+                    muteChord.OnNext(Unit.Default);
+                    return;
+                }
+
                 openNodeParameter.OnNext(Unit.Default);
             }
             else if (context.canceled)
             {
+                // ミュートとして消費した押下は、開いていないパネルを閉じない
+                if (nodeParameterOpenSuppressed)
+                {
+                    nodeParameterOpenSuppressed = false;
+                    return;
+                }
+
                 closeNodeParameter.OnNext(Unit.Default);
+            }
+        }
+
+        public void OnLock(InputAction.CallbackContext context)
+        {
+            if (context.performed)
+            {
+                lockStarted.OnNext(Unit.Default);
             }
         }
 

--- a/Assets/Rector/Scripts/UI/GraphPages/GraphInputAction.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/GraphInputAction.cs
@@ -75,6 +75,7 @@ namespace Rector.UI.GraphPages
         bool navModifierHeld;
         bool grabModifierHeld;
         NavigateDirection chordNavigateDirection;
+        bool chordNeutralRequired;
         bool nodeParameterOpenSuppressed;
 
         bool removeNodeHolding;
@@ -96,11 +97,13 @@ namespace Rector.UI.GraphPages
         {
             Translate = Vector2.zero;
             Zoom = 0f;
-            nodeParameterOpenSuppressed = false;
             // moveGroupDirection はここでリセットしない。MoveGroup は initialStateCheck 付きなので、
             // 倒したまま抜けて戻ると再有効化時に performed が来る。0に戻しておくと
             // 「中立から倒れた」と誤判定して、触っていないのにグループが1つ飛ぶ。
             rectorInput.Graph.Disable();
+            // Disable時のOpenNodeParameterのcancelを飲み込ませてから消す。
+            // 先に消すと、L1+R1を握ったままページを抜けたときcloseNodeParameterが漏れる。
+            nodeParameterOpenSuppressed = false;
         }
 
         public void OnNavigate(InputAction.CallbackContext context)
@@ -138,7 +141,19 @@ namespace Rector.UI.GraphPages
             // 「倒し直した」ことになりグループ内移動が二重発火する。逆に縦横どちらかに寄せると、
             // 右を押した指が角に転がった瞬間に別コマンドが誤発火する。
             var direction = ToNavigateDirection(value);
-            if (direction is not { } d || d == chordNavigateDirection) return;
+            if (direction is not { } d) return;
+
+            // 斜めに倒したまま修飾キーを押した場合は、一度中立を観測するまで発火させない。
+            // ここを通すと、押し込んだ指が縦横に転がっただけで「新しい方向」として発火してしまう。
+            if (chordNeutralRequired)
+            {
+                if (d != NavigateDirection.None) return;
+                chordNeutralRequired = false;
+                chordNavigateDirection = NavigateDirection.None;
+                return;
+            }
+
+            if (d == chordNavigateDirection) return;
 
             chordNavigateDirection = d;
             if (grabModifierHeld)
@@ -354,7 +369,10 @@ namespace Rector.UI.GraphPages
         void BeginChord()
         {
             // 押した時点で既に倒れている十字キーは発火させない。倒し直しを待つ。
-            chordNavigateDirection = ToNavigateDirection(rectorInput.Graph.Navigate.ReadValue<Vector2>()) ?? NavigateDirection.None;
+            // 斜め(判定不能)のときは方向でシードできないので、中立を観測するまで保留する。
+            var seeded = ToNavigateDirection(rectorInput.Graph.Navigate.ReadValue<Vector2>());
+            chordNeutralRequired = seeded is null;
+            chordNavigateDirection = seeded ?? NavigateDirection.None;
             // リピート中のナビゲートも止める
             navigateInputThrottle.SetInput(Vector2.zero);
         }

--- a/Assets/Rector/Scripts/UI/GraphPages/GraphInputAction.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/GraphInputAction.cs
@@ -129,7 +129,7 @@ namespace Rector.UI.GraphPages
         /// <remarks>
         /// 修飾キーを押している間は十字キーを別コマンドとして扱う。
         /// NavModifier(L1/Option): 上下左右ともグループ内に閉じたフォーカス移動。
-        /// GrabModifier(L2/Ctrl): 左右は選択ノードのグループ移動。両方押しはGrab優先。
+        /// GrabModifier(R2/Ctrl): 左右は選択ノードのグループ移動。両方押しはGrab優先。
         /// どれも離散的な操作なのでリピートさせず、方向が新しく確定した瞬間だけ発火させる。
         /// </remarks>
         void HandleChordNavigate(Vector2 value)

--- a/Assets/Rector/Scripts/UI/GraphPages/GraphPage.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/GraphPage.cs
@@ -383,7 +383,8 @@ namespace Rector.UI.GraphPages
             if (Graph.Edges.ContainsKey(new EdgeId(output, input))) return ConnectResult.AlreadyConnected;
 
             // ValidateLoop を CanConnect より先に見るのは、自分自身への接続を Incompatible ではなく
-            // Loop として返すため。HUD は TargetNodeSelection で自ノードを選べないので影響しない。
+            // Loop として返すため。HUD でも自ノードをターゲットにできる(ターゲットカーソルは
+            // ソースの上から始まる)ので、その場合はこの順序によって Loop として弾かれる。
             if (!Graph.ValidateLoop(output, input))
             {
                 RectorLogger.LoopDetected(output.NodeId, input.NodeId);

--- a/Assets/Rector/Scripts/UI/GraphPages/GraphPage.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/GraphPage.cs
@@ -94,7 +94,7 @@ namespace Rector.UI.GraphPages
             stateMap.Add(GraphPageState.TargetNodeSelection, new TargetNodeSelectionInputHandler(this, nodeNavigator));
             stateMap.Add(GraphPageState.TargetSlotSelection, new TargetSlotSelectionInputHandler(this));
             stateMap.Add(GraphPageState.NodeCreation, new NodeCreationInputHandler(createNodeMenuView));
-            stateMap.Add(GraphPageState.NodeParameter, new NodeParameterInputHandler(nodeParameterView));
+            stateMap.Add(GraphPageState.NodeParameter, new NodeParameterInputHandler(this, nodeParameterView));
         }
 
         public void Enter()
@@ -146,12 +146,27 @@ namespace Rector.UI.GraphPages
 
             graphInputAction.Navigate.Subscribe(x => CurrentInputHandler.Navigate(x)).AddTo(disposable);
             graphInputAction.MoveGroup.Subscribe(x => CurrentInputHandler.MoveGroup(x)).AddTo(disposable);
+            graphInputAction.NavigateInGroup.Subscribe(x => CurrentInputHandler.NavigateInGroup(x)).AddTo(disposable);
             graphInputAction.MoveNodeToGroup.Subscribe(x => CurrentInputHandler.MoveNodeToGroup(x)).AddTo(disposable);
             graphInputAction.Submit.Subscribe(_ => CurrentInputHandler.Submit()).AddTo(disposable);
             graphInputAction.Cancel.Subscribe(_ => CurrentInputHandler.Cancel()).AddTo(disposable);
             graphInputAction.Action.Subscribe(_ => CurrentInputHandler.Action()).AddTo(disposable);
             graphInputAction.AddNode.Subscribe(_ => CurrentInputHandler.AddNode()).AddTo(disposable);
             graphInputAction.Mute.Subscribe(_ => CurrentInputHandler.Mute()).AddTo(disposable);
+            // L1+R1のミュートはターゲット選択中には流さない。L1を握ったままR1で差し替え接続の
+            // 構えに入る指の流れで、ターゲットを誤ミュートしないため(キーボードVは従来通り届く)。
+            graphInputAction.MuteChord
+                .Where(_ => State.Value is not (GraphPageState.TargetNodeSelection or GraphPageState.TargetSlotSelection))
+                .Subscribe(_ => CurrentInputHandler.Mute()).AddTo(disposable);
+            // ロックは押した瞬間に現在のフォーカスへ寄せる。以後の追従は
+            // MoveContentToMakeNodeVisibleの既存呼び出し(選択・ターゲット変更時)が拾う。
+            graphInputAction.LockStarted.Subscribe(_ =>
+            {
+                if (GetFocusNodeForCurrentState() is { } focus)
+                {
+                    graphContentTransformer.MoveContentToMakeNodeVisible(focus);
+                }
+            }).AddTo(disposable);
             graphInputAction.OpenNodeParameter.Subscribe(_ => CurrentInputHandler.OpenNodeParameter()).AddTo(disposable);
             graphInputAction.CloseNodeParameter.Subscribe(_ => CurrentInputHandler.CloseNodeParameter()).AddTo(disposable);
             graphInputAction.RemoveNode.Subscribe(x => CurrentInputHandler.RemoveNode(x)).AddTo(disposable);
@@ -302,6 +317,55 @@ namespace Rector.UI.GraphPages
             State.Value = GraphPageState.NodeSelection;
         }
 
+        /// <summary>ノードのミュートをトグルしてログを残す。全ハンドラ共通の入り口。</summary>
+        public void ToggleMute(LayeredNode? node)
+        {
+            if (node is not { NodeView: { Node: var target } }) return;
+
+            var mute = !target.IsMuted.Value;
+            target.IsMuted.Value = mute;
+            RectorLogger.ToggleMute(target, mute);
+        }
+
+        /// <summary>
+        /// ターゲットをソースに引き継いでスロット選択へ移る。ターゲット選択中の△/Cで、
+        /// ソース選択まで戻らずに、いま指しているノードから続けて次のエッジを張るための操作。
+        /// </summary>
+        /// <remarks>
+        /// Target系のクリアはセッターを通さない。SetTargetSlot(null)/SetTargetNode(null)は
+        /// 「これからSelectedになるもの」の選択表示を外したり、旧SelectedNodeへ視点を
+        /// 戻したりしてしまう(直接代入は<see cref="SlotSelectionInputHandler.Submit"/>と同じ流儀)。
+        /// </remarks>
+        public void PromoteTargetToSource()
+        {
+            switch (State.Value)
+            {
+                case GraphPageState.TargetNodeSelection:
+                    {
+                        // CLIからStateを直接動かされた場合に備えてnullを弾く
+                        if (TargetNode is not { } target) return;
+                        if (target.InputSlotCount == 0 && target.OutputSlotCount == 0) return;
+
+                        TargetNode = null;
+                        SelectNode(target);
+                        SelectSlot(target.InputSlotCount > 0 ? target.NodeView.Node.InputSlots[0] : target.NodeView.Node.OutputSlots[0]);
+                        State.Value = GraphPageState.SlotSelection;
+                        break;
+                    }
+                case GraphPageState.TargetSlotSelection:
+                    {
+                        if (TargetNode is not { } target || TargetSlot is not { } targetSlot) return;
+
+                        TargetNode = null;
+                        TargetSlot = null;
+                        SelectNode(target);
+                        SelectSlot(targetSlot);
+                        State.Value = GraphPageState.SlotSelection;
+                        break;
+                    }
+            }
+        }
+
         public bool DisconnectSlots(OutputSlot output, InputSlot input)
         {
             if (!Graph.RemoveEdge(new EdgeId(output, input))) return false;
@@ -407,32 +471,19 @@ namespace Rector.UI.GraphPages
                 widthRetryCount = 0;
             }
 
-            switch (State.Value)
+            if (GetFocusNodeForCurrentState() is { } focus)
             {
-                case GraphPageState.NodeSelection:
-                case GraphPageState.SlotSelection:
-                case GraphPageState.NodeParameter:
-                case GraphPageState.NodeCreation:
-                    if (SelectedNode is not null)
-                    {
-                        graphContentTransformer.MoveContentToMakeNodeVisible(SelectedNode);
-                    }
-                    break;
-                case GraphPageState.TargetNodeSelection:
-                case GraphPageState.TargetSlotSelection:
-                    if (TargetNode is not null)
-                    {
-                        graphContentTransformer.MoveContentToMakeNodeVisible(TargetNode);
-                    }
-                    else if (SelectedNode is not null)
-                    {
-                        graphContentTransformer.MoveContentToMakeNodeVisible(SelectedNode);
-                    }
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
+                graphContentTransformer.MoveContentToMakeNodeVisible(focus);
             }
         }
+
+        /// <summary>Stateに応じた「いま操作しているノード」。ターゲット選択中はターゲット側。</summary>
+        LayeredNode? GetFocusNodeForCurrentState() =>
+            State.Value switch
+            {
+                GraphPageState.TargetNodeSelection or GraphPageState.TargetSlotSelection => TargetNode ?? SelectedNode,
+                _ => SelectedNode,
+            };
 
         void IDisposable.Dispose()
         {

--- a/Assets/Rector/Scripts/UI/GraphPages/GraphPageInputHandler.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/GraphPageInputHandler.cs
@@ -29,7 +29,7 @@ namespace Rector.UI.GraphPages
         }
 
         /// <summary>
-        /// 選択中のノードを隣のグループへ移す。directionは-1か1。GrabModifier(L2/Ctrl)を押しながらの左右。
+        /// 選択中のノードを隣のグループへ移す。directionは-1か1。GrabModifier(R2/Ctrl)を押しながらの左右。
         /// </summary>
         public virtual void MoveNodeToGroup(int direction)
         {

--- a/Assets/Rector/Scripts/UI/GraphPages/GraphPageInputHandler.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/GraphPageInputHandler.cs
@@ -9,11 +9,11 @@ namespace Rector.UI.GraphPages
         }
 
         /// <summary>
-        /// フォーカスを隣のグループへ移す。directionは-1か1。
+        /// フォーカスを隣のグループへ移す。directionは-1か1。キーボードQ/E。
         /// </summary>
         /// <remarks>
-        /// ノード自体のグループ移動は <see cref="MoveNodeToGroup"/> が持つ。同じ左スティックの
-        /// 操作がStateによって別の意味にならないよう、ここでは移すのはフォーカスだけにする。
+        /// ノード自体のグループ移動は <see cref="MoveNodeToGroup"/>(GrabModifier側)が持つ。
+        /// 同じ操作がStateによって別の意味にならないよう、ここで移すのはフォーカスだけにする。
         /// 実装しないStateでは何もしない。
         /// </remarks>
         public virtual void MoveGroup(int direction)
@@ -21,7 +21,15 @@ namespace Rector.UI.GraphPages
         }
 
         /// <summary>
-        /// 選択中のノードを隣のグループへ移す。directionは-1か1。NodeModifier(L1/Option)を押しながらの左右。
+        /// フォーカスを同じグループ内だけで動かす。directionは上下左右いずれかの単位ベクトル。
+        /// NavModifier(L1/Option)を押しながらの十字キー。
+        /// </summary>
+        public virtual void NavigateInGroup(Vector2Int direction)
+        {
+        }
+
+        /// <summary>
+        /// 選択中のノードを隣のグループへ移す。directionは-1か1。GrabModifier(L2/Ctrl)を押しながらの左右。
         /// </summary>
         public virtual void MoveNodeToGroup(int direction)
         {

--- a/Assets/Rector/Scripts/UI/GraphPages/NodeNavigator.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/NodeNavigator.cs
@@ -128,7 +128,8 @@ namespace Rector.UI.GraphPages
 
         /// <summary>
         /// 同じグループ内だけで上下に移動する。隣のレイヤーから順に、グループ内のノードが
-        /// いる最初のレイヤーでx座標が一番近いノードを返す。いなければnull。
+        /// いる最初のレイヤーでx座標が一番近いノードを返す。端まで行ったら反対側の端へ
+        /// 回り込む。いなければnull。
         /// </summary>
         public LayeredNode FindVerticalInSameGroup(LayeredNode current, bool up)
         {

--- a/Assets/Rector/Scripts/UI/GraphPages/NodeNavigator.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/NodeNavigator.cs
@@ -17,7 +17,9 @@ namespace Rector.UI.GraphPages
 
         /// <remarks>
         /// フォーカスの移動はグループを跨ぐ。グループ内に閉じるとグループを跨いだ確認がしづらい。
-        /// 左スティックの MoveGroup は「隣のグループへ一気に飛ぶ」ための別経路。
+        /// 左右はグループ内の行を歩き、グループの端まで来たら隣のグループの最近傍へ入る。
+        /// グループ内に閉じた移動は NavModifier(L1) 側の別経路
+        /// (<see cref="FindHorizontalInSameGroup"/> / <see cref="FindVerticalInSameGroup"/>)。
         /// </remarks>
         public LayeredNode SelectNextNode(LayeredNode current, Vector2 input)
         {
@@ -28,21 +30,30 @@ namespace Rector.UI.GraphPages
 
             if (direction is Direction.Left or Direction.Right)
             {
-                // レイヤーは全グループを連結した1行。グループ境界では隣のグループへそのまま進み、
-                // 行の端まで行ったら反対の端へ回り込む。
                 var step = direction == Direction.Right ? 1 : -1;
-                var count = currentLayer.Count;
+                var group = groups.Fold(current.Group);
+
+                // グループ内では同じ行を歩く。行は全グループを連結した1行なので、
+                // 進んだ先の実ノードが同グループのうちは行内の隣がそのまま次のノード。
                 var start = currentLayer.IndexOf(current);
-                for (var i = 1; i <= count; i++)
+                for (var i = start + step; i >= 0 && i < currentLayer.Count; i += step)
                 {
-                    var next = currentLayer[((start + step * i) % count + count) % count];
-                    if (next is LayeredNode layeredNode)
-                    {
-                        return layeredNode;
-                    }
+                    if (currentLayer[i] is not LayeredNode inRow) continue;
+                    if (groups.Fold(inRow.Group) == group) return inRow;
+                    break; // 実ノードが別グループ = グループの端まで来た
                 }
 
-                return current;
+                // グループの端では行を続けず、隣のグループの最近傍(レイヤー優先、次にx)へ入る。
+                // 隣のグループの同じ行にノードがいればレイヤー距離0で従来の行渡りと同じ遷移になり、
+                // いないときだけ「遠くの行仲間」ではなく空間的に近いノードが選ばれる。
+                var hop = FindNodeInAdjacentGroup(current, step, groups.CurrentCount);
+                if (hop != null && groups.Fold(hop.Group) != group)
+                {
+                    return hop;
+                }
+
+                // 飛べる先が無い(実質1グループ)なら、従来通り行内でラップする
+                return FindHorizontalInSameGroup(current, step) ?? current;
             }
 
             var up = direction == Direction.Up;
@@ -67,6 +78,14 @@ namespace Rector.UI.GraphPages
                 return crossing;
             }
 
+            // つながりが無いときは空間的に近いノードへ。まず同グループ内を優先し、
+            // いなければ全グループから探す(上下移動で気づいたら隣のグループに居る事故を防ぐ)。
+            var inGroup = FindVerticalInSameGroup(current, up);
+            if (inGroup != null)
+            {
+                return inGroup;
+            }
+
             // 隣のレイヤーで一番x座標が近いノードに移動する。ノードのないレイヤーは飛ばす。
             for (var i = 0; i < layers.Count; i++)
             {
@@ -82,6 +101,59 @@ namespace Rector.UI.GraphPages
             }
 
             return current;
+        }
+
+        /// <summary>
+        /// 同じグループ内だけで、同じ行(レイヤー)の隣のノードを返す。グループ内の端まで
+        /// 行ったらグループ内の反対端へ回り込む。行内に自分しかいなければnull。
+        /// </summary>
+        public LayeredNode FindHorizontalInSameGroup(LayeredNode current, int direction)
+        {
+            var row = graph.Layers[current.Layer];
+            var group = groups.Fold(current.Group);
+            var count = row.Count;
+            var start = row.IndexOf(current);
+
+            for (var i = 1; i < count; i++)
+            {
+                var next = row[((start + direction * i) % count + count) % count];
+                if (next is LayeredNode layeredNode && groups.Fold(layeredNode.Group) == group)
+                {
+                    return layeredNode;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// 同じグループ内だけで上下に移動する。隣のレイヤーから順に、グループ内のノードが
+        /// いる最初のレイヤーでx座標が一番近いノードを返す。いなければnull。
+        /// </summary>
+        public LayeredNode FindVerticalInSameGroup(LayeredNode current, bool up)
+        {
+            var layers = graph.Layers;
+            var group = groups.Fold(current.Group);
+            var layerIndex = current.Layer;
+
+            // 自分のいるレイヤーは走査しない(layers.Count - 1回で他レイヤーを一巡)。
+            // 含めると「グループ内に縦の他ノードがいない」ときに横並びの隣人やcurrent自身へ
+            // 「上下移動」してしまう。
+            for (var i = 0; i < layers.Count - 1; i++)
+            {
+                layerIndex = (layerIndex + (up ? -1 : 1) + layers.Count) % layers.Count;
+                var candidate = layers[layerIndex]
+                    .OfType<LayeredNode>()
+                    .Where(x => groups.Fold(x.Group) == group)
+                    .OrderBy(x => Mathf.Abs(x.TargetPosition.x - current.TargetPosition.x))
+                    .FirstOrDefault();
+                if (candidate != null)
+                {
+                    return candidate;
+                }
+            }
+
+            return null;
         }
 
         LayeredNode FindAcrossGroups(LayeredNode current, bool up)

--- a/Assets/Rector/Scripts/UI/GraphPages/NodeParameterInputHandler.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/NodeParameterInputHandler.cs
@@ -5,10 +5,12 @@ namespace Rector.UI.GraphPages
 {
     public sealed class NodeParameterInputHandler : GraphPageInputHandler
     {
+        readonly GraphPage graphPage;
         readonly NodeParameterView view;
 
-        public NodeParameterInputHandler(NodeParameterView view)
+        public NodeParameterInputHandler(GraphPage graphPage, NodeParameterView view)
         {
+            this.graphPage = graphPage;
             this.view = view;
         }
 
@@ -16,5 +18,8 @@ namespace Rector.UI.GraphPages
         public override void Action() => view.Action();
         public override void CloseNodeParameter() => view.CloseNodeParameter();
         public override void Cancel() => view.CloseNodeParameter();
+
+        // パネルを開いたままL1を重ねたミュート(MuteChord)がここに届く
+        public override void Mute() => graphPage.ToggleMute(graphPage.SelectedNode);
     }
 }

--- a/Assets/Rector/Scripts/UI/GraphPages/NodeSelectionInputHandler.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/NodeSelectionInputHandler.cs
@@ -39,6 +39,19 @@ namespace Rector.UI.GraphPages
             graphPage.MoveActiveGroup(direction);
         }
 
+        public override void NavigateInGroup(Vector2Int direction)
+        {
+            if (graphPage.SelectedNode is not { } selected) return;
+
+            var next = direction.y != 0
+                ? nodeNavigator.FindVerticalInSameGroup(selected, direction.y > 0)
+                : nodeNavigator.FindHorizontalInSameGroup(selected, direction.x);
+            if (next != null)
+            {
+                graphPage.SelectNode(next);
+            }
+        }
+
         public override void MoveNodeToGroup(int direction)
         {
             graphPage.MoveSelectedNodeToGroup(direction);
@@ -110,12 +123,7 @@ namespace Rector.UI.GraphPages
 
         public override void Mute()
         {
-            if (graphPage.SelectedNode is { NodeView: { Node: var selectedNode } })
-            {
-                var mute = !selectedNode.IsMuted.Value;
-                selectedNode.IsMuted.Value = mute;
-                RectorLogger.ToggleMute(selectedNode, mute);
-            }
+            graphPage.ToggleMute(graphPage.SelectedNode);
         }
 
         public override void OpenNodeParameter()

--- a/Assets/Rector/Scripts/UI/GraphPages/SlotSelectionInputHandler.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/SlotSelectionInputHandler.cs
@@ -126,10 +126,7 @@ namespace Rector.UI.GraphPages
 
         public override void Mute()
         {
-            if (graphPage.SelectedNode is { NodeView: { Node: var selectedNode } })
-            {
-                selectedNode.IsMuted.Value = !selectedNode.IsMuted.Value;
-            }
+            graphPage.ToggleMute(graphPage.SelectedNode);
         }
     }
 }

--- a/Assets/Rector/Scripts/UI/GraphPages/TargetNodeSelectionInputHandler.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/TargetNodeSelectionInputHandler.cs
@@ -25,6 +25,34 @@ namespace Rector.UI.GraphPages
             }
         }
 
+        public override void MoveGroup(int direction)
+        {
+            // MoveActiveGroupはSelectedNode(ソース)を動かしてしまうので、ターゲット用の別経路
+            var next = navigator.FindNodeInAdjacentGroup(graphPage.TargetNode, direction, graphPage.Groups.CurrentCount);
+            if (next != null)
+            {
+                graphPage.SetTargetNode(next);
+            }
+        }
+
+        public override void NavigateInGroup(Vector2Int direction)
+        {
+            if (graphPage.TargetNode is not { } target) return;
+
+            var next = direction.y != 0
+                ? navigator.FindVerticalInSameGroup(target, direction.y > 0)
+                : navigator.FindHorizontalInSameGroup(target, direction.x);
+            if (next != null)
+            {
+                graphPage.SetTargetNode(next);
+            }
+        }
+
+        public override void AddNode()
+        {
+            graphPage.PromoteTargetToSource();
+        }
+
         public override void Cancel()
         {
             graphPage.SetTargetNode(null);
@@ -57,10 +85,7 @@ namespace Rector.UI.GraphPages
 
         public override void Mute()
         {
-            if (graphPage.TargetNode is { NodeView: { Node: var targetNode } })
-            {
-                targetNode.IsMuted.Value = !targetNode.IsMuted.Value;
-            }
+            graphPage.ToggleMute(graphPage.TargetNode);
         }
     }
 }

--- a/Assets/Rector/Scripts/UI/GraphPages/TargetSlotSelectionInputHandler.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/TargetSlotSelectionInputHandler.cs
@@ -78,13 +78,14 @@ namespace Rector.UI.GraphPages
             graphPage.TargetNode?.NodeView.Node.DoAction();
         }
 
+        public override void AddNode()
+        {
+            graphPage.PromoteTargetToSource();
+        }
 
         public override void Mute()
         {
-            if (graphPage.TargetNode is { NodeView: { Node: var targetNode } })
-            {
-                targetNode.IsMuted.Value = !targetNode.IsMuted.Value;
-            }
+            graphPage.ToggleMute(graphPage.TargetNode);
         }
     }
 }

--- a/Assets/Rector/Settings/RectorInput.inputactions
+++ b/Assets/Rector/Settings/RectorInput.inputactions
@@ -142,7 +142,7 @@
                 },
                 {
                     "name": "Zoom",
-                    "type": "PassThrough",
+                    "type": "Value",
                     "id": "5eb0c98f-5742-4243-8bc9-2687be779826",
                     "expectedControlType": "Axis",
                     "processors": "",

--- a/Assets/Rector/Settings/RectorInput.inputactions
+++ b/Assets/Rector/Settings/RectorInput.inputactions
@@ -78,9 +78,27 @@
                     "initialStateCheck": false
                 },
                 {
-                    "name": "NodeModifier",
+                    "name": "NavModifier",
                     "type": "Button",
                     "id": "80adc06a-a353-4f9f-ba4e-33bf59dcefaa",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "GrabModifier",
+                    "type": "Button",
+                    "id": "42602014-d6ee-4fa8-be7f-5de191d1a6db",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "Lock",
+                    "type": "Button",
+                    "id": "6f985f69-b9b2-4366-b0de-50373d77decf",
                     "expectedControlType": "",
                     "processors": "",
                     "interactions": "",
@@ -433,7 +451,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "NodeModifier",
+                    "action": "NavModifier",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
@@ -444,7 +462,51 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "NodeModifier",
+                    "action": "NavModifier",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "20f8af16-4d2c-48ef-9662-510ea1664d47",
+                    "path": "<Gamepad>/leftTrigger",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "GrabModifier",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "46485fac-71ff-461e-a308-773847cfc799",
+                    "path": "<Keyboard>/ctrl",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "GrabModifier",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "09136dca-c62b-46b9-a3e7-55cd9bb3cb68",
+                    "path": "<Gamepad>/rightTrigger",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Lock",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "112e2868-bd45-4429-b6d9-1fe7bba76690",
+                    "path": "<Keyboard>/tab",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Lock",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
@@ -526,37 +588,15 @@
                     "isPartOfComposite": false
                 },
                 {
-                    "name": "1D Axis",
-                    "id": "2f61fea0-52df-4807-88a3-6a4563eceabe",
-                    "path": "1DAxis",
+                    "name": "",
+                    "id": "455117e2-4359-4c37-9607-d91a5845056e",
+                    "path": "<Gamepad>/leftStick/y",
                     "interactions": "",
-                    "processors": "",
+                    "processors": "AxisDeadzone",
                     "groups": "",
                     "action": "Zoom",
-                    "isComposite": true,
+                    "isComposite": false,
                     "isPartOfComposite": false
-                },
-                {
-                    "name": "negative",
-                    "id": "3145a9a5-5238-4a09-9491-f1fc4623144d",
-                    "path": "<Gamepad>/leftTrigger",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "",
-                    "action": "Zoom",
-                    "isComposite": false,
-                    "isPartOfComposite": true
-                },
-                {
-                    "name": "positive",
-                    "id": "d0a1707e-9f53-43b9-9bdf-a547ff1cc284",
-                    "path": "<Gamepad>/rightTrigger",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "",
-                    "action": "Zoom",
-                    "isComposite": false,
-                    "isPartOfComposite": true
                 },
                 {
                     "name": "1D Axis",
@@ -676,17 +716,6 @@
                     "processors": "",
                     "groups": "",
                     "action": "ResetTransform",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
-                    "id": "ea5931e7-cf5d-4aec-bae9-65d4c42466fd",
-                    "path": "<Gamepad>/leftStick",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": ";Gamepad",
-                    "action": "MoveGroup",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },

--- a/Assets/Rector/Settings/RectorInput.inputactions
+++ b/Assets/Rector/Settings/RectorInput.inputactions
@@ -469,7 +469,7 @@
                 {
                     "name": "",
                     "id": "20f8af16-4d2c-48ef-9662-510ea1664d47",
-                    "path": "<Gamepad>/leftTrigger",
+                    "path": "<Gamepad>/rightTrigger",
                     "interactions": "",
                     "processors": "",
                     "groups": "",
@@ -491,7 +491,7 @@
                 {
                     "name": "",
                     "id": "09136dca-c62b-46b9-a3e7-55cd9bb3cb68",
-                    "path": "<Gamepad>/rightTrigger",
+                    "path": "<Gamepad>/leftTrigger",
                     "interactions": "",
                     "processors": "",
                     "groups": "",


### PR DESCRIPTION
## Summary

Rethinks the gamepad/keyboard layout around a small grammar (#50): the left hand navigates and edits, the right hand controls the view, and each modifier owns one meaning across all four d-pad directions.

| Input | Meaning |
|---|---|
| D-pad | Free navigation (unchanged: follows edges, crosses groups) |
| **L1 + d-pad** | Focus movement confined to the current group (all four directions) |
| **R2 + left/right** | Move the selected node to the adjacent group |
| **L1 + R1** | Mute toggle (press-order independent) |
| R1 hold | Parameter panel (unchanged, incl. replace-connect on submit) |
| **L2 / Tab hold** | Camera lock: follow the focused node while held |
| **Left stick vertical** | Zoom, analog speed (up = in) |
| Right stick / R3 | Pan / reset (unchanged) |
| **△ / C during target selection** | Promote the target to source and continue edge creation |

Keyboard: L1=Option, L2=Ctrl (use Ctrl+A/D on macOS; Ctrl+arrows collides with Mission Control), Lock=Tab, V stays as direct mute, Q/E group jump and U/O zoom remain.

## Details

- `RectorInput.inputactions`: renamed `NodeModifier` → `NavModifier`, added `GrabModifier` (R2/Ctrl) and `Lock` (L2/Tab), rebound `Zoom` to `leftStick/y` (AxisDeadzone) and removed the L2/R2 axis and the left-stick `MoveGroup` binding. `RectorInput.cs` regenerated
- `GraphInputAction`: single chord state shared by both modifiers (discrete, no repeat, diagonal-hold semantics preserved); grab wins when both are held. L1+R1 fires a separate `MuteChord` which `GraphPage` drops during target selection so the replace-connect R1 hold cannot accidentally mute the target. `IsLockHeld` polls the action to avoid stale state
- `NodeNavigator`:
  - free left/right now walks the row within the group and, at the group edge, enters the adjacent group at its nearest node (`FindNodeInAdjacentGroup`); with effectively one group it falls back to the old row wrap. When the adjacent group has a node on the same row this is identical to the previous behavior
  - free up/down keeps edge-following priority; only the spatial fallback now prefers same-group candidates
  - new `FindHorizontalInSameGroup` / `FindVerticalInSameGroup` back the L1 confined channel (wrap within the group, never land on your own row vertically)
- `GraphPage`: `PromoteTargetToSource()` (clears target fields without the setters so the promoted slot keeps its highlight), `ToggleMute()` unifies toggling+logging across all handlers, lock press centers on the state-appropriate focus node via `GetFocusNodeForCurrentState()`
- `GraphContentTransformer`: follow condition ORs `IsLockHeld`; zoom uses the analog value instead of `Mathf.Sign`
- `TargetNodeSelectionInputHandler`: group jump and in-group navigation now also work while picking a target (moving the target, not the source)

## Test plan

- [x] `unity command recompile` clean, no console errors
- [x] Play-mode verification via CLI/eval: in-group navigation (wrap, confinement, cross-group edge-following intact), boundary hop (adjacent-group nearest, row-wrap fallback with one group), promote from both target states (highlights and state fields), mute helper
- [ ] Gamepad feel: chord misfires (diagonal rolls, L1↔R2 together), L1+d-pad repeat need, zoom speed/polarity, lock feel
- [ ] Tab lock does not fight UI Toolkit tab focus

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)