### PR TITLE
fix: unify Settings button label casing to Title Case

### DIFF
--- a/Assets/Rector/Scripts/UI/Hud/SystemPageModel.cs
+++ b/Assets/Rector/Scripts/UI/Hud/SystemPageModel.cs
@@ -34,8 +34,8 @@ namespace Rector.UI.Hud
             buttons = new RectorButtonState[]
             {
                 new("Audio Settings", ShowAudioSettings),
-                new("Display settings", ShowDisplaySettings),
-                new("Graph settings", ShowGraphSettings),
+                new("Display Settings", ShowDisplaySettings),
+                new("Graph Settings", ShowGraphSettings),
                 new("Copyright Notices", ShowCopyrightNotices),
                 new("Exit", ExitApplication),
             };


### PR DESCRIPTION
Closes #53

The System page menu mixed "Audio Settings" with "Display settings" / "Graph settings". All user-visible labels in the codebase follow Title Case (e.g. "Copyright Notices", "Follow Focus"), so the two lowercase entries are updated to "Display Settings" and "Graph Settings".

These three button labels in `SystemPageModel.cs` are the only user-visible "settings" strings in the project — no UXML, scene, or prefab text is affected. Element names like `display-settings-page` and class names are identifiers and stay unchanged.

Verified by compiling the worktree sources with the Unity-bundled Roslyn (exit 0) and running `dotnet format` on the changed file (no diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)