### PR TITLE
change: simplify controller navigation and anchor the lock follow

### DIFF
--- a/Assets/Rector/Scripts/RectorInput.cs
+++ b/Assets/Rector/Scripts/RectorInput.cs
@@ -175,16 +175,6 @@ namespace Rector
                     ""priority"": 0
                 },
                 {
-                    ""name"": ""NavModifier"",
-                    ""type"": ""Button"",
-                    ""id"": ""80adc06a-a353-4f9f-ba4e-33bf59dcefaa"",
-                    ""expectedControlType"": """",
-                    ""processors"": """",
-                    ""interactions"": """",
-                    ""initialStateCheck"": true,
-                    ""priority"": 0
-                },
-                {
                     ""name"": ""GrabModifier"",
                     ""type"": ""Button"",
                     ""id"": ""42602014-d6ee-4fa8-be7f-5de191d1a6db"",
@@ -553,28 +543,6 @@ namespace Rector
                 },
                 {
                     ""name"": """",
-                    ""id"": ""19a43804-cd1c-49c8-bd19-2f5f90f907b1"",
-                    ""path"": ""<Gamepad>/leftShoulder"",
-                    ""interactions"": """",
-                    ""processors"": """",
-                    ""groups"": """",
-                    ""action"": ""NavModifier"",
-                    ""isComposite"": false,
-                    ""isPartOfComposite"": false
-                },
-                {
-                    ""name"": """",
-                    ""id"": ""c610c862-d97f-4805-9c9a-46c1aa507aca"",
-                    ""path"": ""<Keyboard>/alt"",
-                    ""interactions"": """",
-                    ""processors"": """",
-                    ""groups"": """",
-                    ""action"": ""NavModifier"",
-                    ""isComposite"": false,
-                    ""isPartOfComposite"": false
-                },
-                {
-                    ""name"": """",
                     ""id"": ""20f8af16-4d2c-48ef-9662-510ea1664d47"",
                     ""path"": ""<Gamepad>/rightTrigger"",
                     ""interactions"": """",
@@ -621,6 +589,17 @@ namespace Rector
                     ""name"": """",
                     ""id"": ""d6c9b53e-cdb8-45d5-a10d-19b5fb3223d9"",
                     ""path"": ""<Keyboard>/v"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Mute"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""ada450f2-a095-4e98-92b3-8af97af5fa5d"",
+                    ""path"": ""<Gamepad>/leftShoulder"",
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
@@ -1248,7 +1227,6 @@ namespace Rector
             m_Graph_AddNode = m_Graph.FindAction("AddNode", throwIfNotFound: true);
             m_Graph_RemoveEdge = m_Graph.FindAction("RemoveEdge", throwIfNotFound: true);
             m_Graph_RemoveNode = m_Graph.FindAction("RemoveNode", throwIfNotFound: true);
-            m_Graph_NavModifier = m_Graph.FindAction("NavModifier", throwIfNotFound: true);
             m_Graph_GrabModifier = m_Graph.FindAction("GrabModifier", throwIfNotFound: true);
             m_Graph_Lock = m_Graph.FindAction("Lock", throwIfNotFound: true);
             m_Graph_Mute = m_Graph.FindAction("Mute", throwIfNotFound: true);
@@ -1357,7 +1335,6 @@ namespace Rector
         private readonly InputAction m_Graph_AddNode;
         private readonly InputAction m_Graph_RemoveEdge;
         private readonly InputAction m_Graph_RemoveNode;
-        private readonly InputAction m_Graph_NavModifier;
         private readonly InputAction m_Graph_GrabModifier;
         private readonly InputAction m_Graph_Lock;
         private readonly InputAction m_Graph_Mute;
@@ -1410,10 +1387,6 @@ namespace Rector
             /// Provides access to the underlying input action "Graph/RemoveNode".
             /// </summary>
             public InputAction @RemoveNode => m_Wrapper.m_Graph_RemoveNode;
-            /// <summary>
-            /// Provides access to the underlying input action "Graph/NavModifier".
-            /// </summary>
-            public InputAction @NavModifier => m_Wrapper.m_Graph_NavModifier;
             /// <summary>
             /// Provides access to the underlying input action "Graph/GrabModifier".
             /// </summary>
@@ -1500,9 +1473,6 @@ namespace Rector
                 @RemoveNode.started += instance.OnRemoveNode;
                 @RemoveNode.performed += instance.OnRemoveNode;
                 @RemoveNode.canceled += instance.OnRemoveNode;
-                @NavModifier.started += instance.OnNavModifier;
-                @NavModifier.performed += instance.OnNavModifier;
-                @NavModifier.canceled += instance.OnNavModifier;
                 @GrabModifier.started += instance.OnGrabModifier;
                 @GrabModifier.performed += instance.OnGrabModifier;
                 @GrabModifier.canceled += instance.OnGrabModifier;
@@ -1565,9 +1535,6 @@ namespace Rector
                 @RemoveNode.started -= instance.OnRemoveNode;
                 @RemoveNode.performed -= instance.OnRemoveNode;
                 @RemoveNode.canceled -= instance.OnRemoveNode;
-                @NavModifier.started -= instance.OnNavModifier;
-                @NavModifier.performed -= instance.OnNavModifier;
-                @NavModifier.canceled -= instance.OnNavModifier;
                 @GrabModifier.started -= instance.OnGrabModifier;
                 @GrabModifier.performed -= instance.OnGrabModifier;
                 @GrabModifier.canceled -= instance.OnGrabModifier;
@@ -1864,13 +1831,6 @@ namespace Rector
             /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
             /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
             void OnRemoveNode(InputAction.CallbackContext context);
-            /// <summary>
-            /// Method invoked when associated input action "NavModifier" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
-            /// </summary>
-            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
-            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
-            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
-            void OnNavModifier(InputAction.CallbackContext context);
             /// <summary>
             /// Method invoked when associated input action "GrabModifier" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
             /// </summary>

--- a/Assets/Rector/Scripts/UI/GraphPages/GraphContentTransformer.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/GraphContentTransformer.cs
@@ -23,6 +23,12 @@ namespace Rector.UI.GraphPages
         const float MinScale = 0.5f;
         Vector2 offset;
 
+        // Lock(L2/Tab)ホールド中のアンカー追従。押した瞬間のフォーカスノードの画面位置を
+        // アンカーとして記憶し、ホールド中はフォーカスノードがそこに来るように追従する。
+        bool lockHeld;
+        LayeredNode lockNode;
+        Vector2 lockAnchor;
+
         /// <summary>Resetでコンテンツを置くときの、maskの端からの余白。</summary>
         const float ResetMargin = 24f;
 
@@ -100,6 +106,9 @@ namespace Rector.UI.GraphPages
             offset = Vector2.zero;
             SetTranslation(ResetTranslation);
             content.style.scale = Vector3.one;
+            // ロック中のリセットは、リセット後の位置を新しいアンカーとして追認する。
+            // やらないと次のフォーカス移動でリセット前の画面位置へ巻き戻る。
+            RederiveLockAnchor();
         }
 
         void ApplyZoom(float zoom)
@@ -117,6 +126,19 @@ namespace Rector.UI.GraphPages
             var centerPosition = maskCenter - contentLeftUp;
             var diff = centerPosition * (currentScale / beforeScale - 1f);
             SetTranslation(translation - diff);
+
+            // ロック中はマスク中心ズームで動いた先を新しいアンカーとして追認する
+            // (次のフォーカス移動でズーム前の位置へスナップさせない)。
+            RederiveLockAnchor();
+        }
+
+        /// <summary>ロック対象ノードの現在の画面位置でアンカーを取り直す。</summary>
+        void RederiveLockAnchor()
+        {
+            if (lockNode != null)
+            {
+                lockAnchor = translation + lockNode.TargetPosition * currentScale;
+            }
         }
 
 
@@ -152,12 +174,52 @@ namespace Rector.UI.GraphPages
             var delta = new Vector2(translate.x, -translate.y) * 10f;
             SetTranslation(translation + delta);
             offset += delta;
+            // ロック中の手動パンはアンカーごと動かす(次のフォーカス移動と喧嘩させない)
+            if (lockNode != null)
+            {
+                lockAnchor += delta;
+            }
+        }
+
+        /// <summary>
+        /// Lock(L2/Tab)ホールドの開始。nodeの現在の画面位置をアンカーとして記憶する。
+        /// 中央へは寄せない(押した瞬間に画面が動かない)。フォーカスが無いまま押した場合は
+        /// ホールドだけ有効にし、次にフォーカスされたノードがその場でアンカー化される。
+        /// </summary>
+        /// <remarks>アニメーション遷移中でも確定値(translationの目標値)基準で取る。</remarks>
+        public void BeginLockFollow(LayeredNode node)
+        {
+            lockHeld = true;
+            lockNode = node;
+            RederiveLockAnchor();
+        }
+
+        public void EndLockFollow()
+        {
+            lockHeld = false;
+            lockNode = null;
         }
 
         public void MoveContentToMakeNodeVisible(LayeredNode node)
         {
-            // 常時追従の設定に加えて、Lock(L2/Tab)を握っている間だけの一時追従がある
-            if (!viewSettings.FollowSelectedNode.CurrentValue && !graphInputAction.IsLockHeld) return;
+            if (lockHeld)
+            {
+                if (lockNode == null)
+                {
+                    // フォーカス無しでロックを握り、後からノードを選んだ。画面は動かさず
+                    // そのノードのいまの位置をアンカーにする
+                    lockNode = node;
+                    RederiveLockAnchor();
+                    return;
+                }
+
+                // 新しいフォーカスがアンカー位置に来るように追従する(常時追従の設定より優先)
+                lockNode = node;
+                SetTranslation(lockAnchor - node.TargetPosition * currentScale);
+                return;
+            }
+
+            if (!viewSettings.FollowSelectedNode.CurrentValue) return;
 
             // left-top
             var nodePosition = node.TargetPosition * currentScale;

--- a/Assets/Rector/Scripts/UI/GraphPages/GraphInputAction.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/GraphInputAction.cs
@@ -23,9 +23,8 @@ namespace Rector.UI.GraphPages
         readonly Subject<HoldState> removeEdge = new();
         readonly Subject<HoldState> removeNode = new();
         readonly Subject<Unit> mute = new();
-        readonly Subject<Unit> muteChord = new();
-        readonly Subject<Vector2Int> navigateInGroup = new();
         readonly Subject<Unit> lockStarted = new();
+        readonly Subject<Unit> lockEnded = new();
         readonly Subject<Unit> openNodeParameter = new();
         readonly Subject<Unit> closeNodeParameter = new();
         readonly Subject<Unit> openSystem = new();
@@ -43,9 +42,8 @@ namespace Rector.UI.GraphPages
         public Observable<HoldState> RemoveEdge => removeEdge;
         public Observable<HoldState> RemoveNode => removeNode;
         public Observable<Unit> Mute => mute;
-        public Observable<Unit> MuteChord => muteChord;
-        public Observable<Vector2Int> NavigateInGroup => navigateInGroup;
         public Observable<Unit> LockStarted => lockStarted;
+        public Observable<Unit> LockEnded => lockEnded;
         public Observable<Unit> OpenNodeParameter => openNodeParameter;
         public Observable<Unit> CloseNodeParameter => closeNodeParameter;
         public Observable<Unit> OpenSystem => openSystem;
@@ -58,7 +56,6 @@ namespace Rector.UI.GraphPages
         public Vector2 Translate { get; private set; }
         public float Zoom { get; private set; }
         public bool IsNodeParameterOpen => rectorInput.Graph.OpenNodeParameter.IsPressed();
-        public bool IsLockHeld => rectorInput.Graph.Lock.IsPressed();
 
         const float DirectionThreshold = 0.5f;
         int moveGroupDirection;
@@ -72,11 +69,9 @@ namespace Rector.UI.GraphPages
             Right,
         }
 
-        bool navModifierHeld;
         bool grabModifierHeld;
         NavigateDirection chordNavigateDirection;
         bool chordNeutralRequired;
-        bool nodeParameterOpenSuppressed;
 
         bool removeNodeHolding;
         int removeNodeHoldId;
@@ -101,9 +96,6 @@ namespace Rector.UI.GraphPages
             // 倒したまま抜けて戻ると再有効化時に performed が来る。0に戻しておくと
             // 「中立から倒れた」と誤判定して、触っていないのにグループが1つ飛ぶ。
             rectorInput.Graph.Disable();
-            // Disable時のOpenNodeParameterのcancelを飲み込ませてから消す。
-            // 先に消すと、L1+R1を握ったままページを抜けたときcloseNodeParameterが漏れる。
-            nodeParameterOpenSuppressed = false;
         }
 
         public void OnNavigate(InputAction.CallbackContext context)
@@ -120,7 +112,7 @@ namespace Rector.UI.GraphPages
 
         void HandleNavigate(Vector2 value)
         {
-            if (navModifierHeld || grabModifierHeld)
+            if (grabModifierHeld)
             {
                 HandleChordNavigate(value);
                 return;
@@ -130,16 +122,14 @@ namespace Rector.UI.GraphPages
         }
 
         /// <remarks>
-        /// 修飾キーを押している間は十字キーを別コマンドとして扱う。
-        /// NavModifier(L1/Option): 上下左右ともグループ内に閉じたフォーカス移動。
-        /// GrabModifier(R2/Ctrl): 左右は選択ノードのグループ移動。両方押しはGrab優先。
-        /// どれも離散的な操作なのでリピートさせず、方向が新しく確定した瞬間だけ発火させる。
+        /// GrabModifier(R2/Ctrl)を押している間は十字キーを別コマンドとして扱う。
+        /// 左右は選択ノードのグループ移動。離散的な操作なのでリピートさせず、
+        /// 方向が新しく確定した瞬間だけ発火させる。
         /// </remarks>
         void HandleChordNavigate(Vector2 value)
         {
             // 斜めは判定保留(前の方向を維持)。Noneに落とすと、右→右下→右と転がっただけで
-            // 「倒し直した」ことになりグループ内移動が二重発火する。逆に縦横どちらかに寄せると、
-            // 右を押した指が角に転がった瞬間に別コマンドが誤発火する。
+            // 「倒し直した」ことになりグループ移動が二重発火する。
             var direction = ToNavigateDirection(value);
             if (direction is not { } d) return;
 
@@ -155,36 +145,16 @@ namespace Rector.UI.GraphPages
 
             if (d == chordNavigateDirection) return;
 
+            // 上下も含めて方向は常に記録する。消すと右→上→右の転がりで右が再発火しなくなる。
             chordNavigateDirection = d;
-            if (grabModifierHeld)
+            switch (d)
             {
-                switch (d)
-                {
-                    case NavigateDirection.Left:
-                        moveNodeToGroup.OnNext(-1);
-                        break;
-                    case NavigateDirection.Right:
-                        moveNodeToGroup.OnNext(1);
-                        break;
-                }
-            }
-            else
-            {
-                switch (d)
-                {
-                    case NavigateDirection.Left:
-                        navigateInGroup.OnNext(new Vector2Int(-1, 0));
-                        break;
-                    case NavigateDirection.Right:
-                        navigateInGroup.OnNext(new Vector2Int(1, 0));
-                        break;
-                    case NavigateDirection.Up:
-                        navigateInGroup.OnNext(new Vector2Int(0, 1));
-                        break;
-                    case NavigateDirection.Down:
-                        navigateInGroup.OnNext(new Vector2Int(0, -1));
-                        break;
-                }
+                case NavigateDirection.Left:
+                    moveNodeToGroup.OnNext(-1);
+                    break;
+                case NavigateDirection.Right:
+                    moveNodeToGroup.OnNext(1);
+                    break;
             }
         }
 
@@ -327,32 +297,11 @@ namespace Rector.UI.GraphPages
         }
 
         /// <remarks>
-        /// NavModifierは単押しでは何もしない修飾キー。押している間の十字キーを
-        /// <see cref="HandleChordNavigate"/> が拾う。OpenNodeParameter(R1/Shift)と
-        /// 重ねるとミュートトグルになる(押し順非依存)。
+        /// GrabModifierは単押しでは何もしない修飾キー。押している間の十字キーを
+        /// <see cref="HandleChordNavigate"/> が拾う。
         /// initialStateCheck付きなので、押したままページを出入りしても再有効化時に
         /// performedが来て修飾キー状態が復元される。
         /// </remarks>
-        public void OnNavModifier(InputAction.CallbackContext context)
-        {
-            if (context.performed)
-            {
-                navModifierHeld = true;
-                BeginChord();
-                // パネルを開いている指に後から重ねた場合もミュートにする
-                if (rectorInput.Graph.OpenNodeParameter.IsPressed())
-                {
-                    muteChord.OnNext(Unit.Default);
-                }
-            }
-            else if (context.canceled)
-            {
-                // 離した時点で倒れたままの十字キーはナビゲートに引き継がない。
-                // Navigateは値が変わるまでイベントが来ないので、倒し直すまで移動しない。
-                navModifierHeld = false;
-            }
-        }
-
         public void OnGrabModifier(InputAction.CallbackContext context)
         {
             if (context.performed)
@@ -362,6 +311,8 @@ namespace Rector.UI.GraphPages
             }
             else if (context.canceled)
             {
+                // 離した時点で倒れたままの十字キーはナビゲートに引き継がない。
+                // Navigateは値が変わるまでイベントが来ないので、倒し直すまで移動しない。
                 grabModifierHeld = false;
             }
         }
@@ -377,7 +328,7 @@ namespace Rector.UI.GraphPages
             navigateInputThrottle.SetInput(Vector2.zero);
         }
 
-        /// <remarks>キーボード(V)専用の単押しトグル。ゲームパッドはL1+R1(MuteChord)で同じ操作。</remarks>
+        /// <remarks>L1/Vの単押しトグル。</remarks>
         public void OnMute(InputAction.CallbackContext context)
         {
             if (context.performed)
@@ -390,25 +341,10 @@ namespace Rector.UI.GraphPages
         {
             if (context.performed)
             {
-                // NavModifier(L1/Option)を押しながらのときはミュートトグルで、パネルは開かない
-                if (navModifierHeld)
-                {
-                    nodeParameterOpenSuppressed = true;
-                    muteChord.OnNext(Unit.Default);
-                    return;
-                }
-
                 openNodeParameter.OnNext(Unit.Default);
             }
             else if (context.canceled)
             {
-                // ミュートとして消費した押下は、開いていないパネルを閉じない
-                if (nodeParameterOpenSuppressed)
-                {
-                    nodeParameterOpenSuppressed = false;
-                    return;
-                }
-
                 closeNodeParameter.OnNext(Unit.Default);
             }
         }
@@ -418,6 +354,10 @@ namespace Rector.UI.GraphPages
             if (context.performed)
             {
                 lockStarted.OnNext(Unit.Default);
+            }
+            else if (context.canceled)
+            {
+                lockEnded.OnNext(Unit.Default);
             }
         }
 

--- a/Assets/Rector/Scripts/UI/GraphPages/GraphPage.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/GraphPage.cs
@@ -146,27 +146,18 @@ namespace Rector.UI.GraphPages
 
             graphInputAction.Navigate.Subscribe(x => CurrentInputHandler.Navigate(x)).AddTo(disposable);
             graphInputAction.MoveGroup.Subscribe(x => CurrentInputHandler.MoveGroup(x)).AddTo(disposable);
-            graphInputAction.NavigateInGroup.Subscribe(x => CurrentInputHandler.NavigateInGroup(x)).AddTo(disposable);
             graphInputAction.MoveNodeToGroup.Subscribe(x => CurrentInputHandler.MoveNodeToGroup(x)).AddTo(disposable);
             graphInputAction.Submit.Subscribe(_ => CurrentInputHandler.Submit()).AddTo(disposable);
             graphInputAction.Cancel.Subscribe(_ => CurrentInputHandler.Cancel()).AddTo(disposable);
             graphInputAction.Action.Subscribe(_ => CurrentInputHandler.Action()).AddTo(disposable);
             graphInputAction.AddNode.Subscribe(_ => CurrentInputHandler.AddNode()).AddTo(disposable);
             graphInputAction.Mute.Subscribe(_ => CurrentInputHandler.Mute()).AddTo(disposable);
-            // L1+R1のミュートはターゲット選択中には流さない。L1を握ったままR1で差し替え接続の
-            // 構えに入る指の流れで、ターゲットを誤ミュートしないため(キーボードVは従来通り届く)。
-            graphInputAction.MuteChord
-                .Where(_ => State.Value is not (GraphPageState.TargetNodeSelection or GraphPageState.TargetSlotSelection))
-                .Subscribe(_ => CurrentInputHandler.Mute()).AddTo(disposable);
-            // ロックは押した瞬間に現在のフォーカスへ寄せる。以後の追従は
+            // ロックは押した瞬間の画面位置をアンカーにする(中央へは寄せない)。以後の追従は
             // MoveContentToMakeNodeVisibleの既存呼び出し(選択・ターゲット変更時)が拾う。
-            graphInputAction.LockStarted.Subscribe(_ =>
-            {
-                if (GetFocusNodeForCurrentState() is { } focus)
-                {
-                    graphContentTransformer.MoveContentToMakeNodeVisible(focus);
-                }
-            }).AddTo(disposable);
+            graphInputAction.LockStarted
+                .Subscribe(_ => graphContentTransformer.BeginLockFollow(GetFocusNodeForCurrentState())).AddTo(disposable);
+            graphInputAction.LockEnded
+                .Subscribe(_ => graphContentTransformer.EndLockFollow()).AddTo(disposable);
             graphInputAction.OpenNodeParameter.Subscribe(_ => CurrentInputHandler.OpenNodeParameter()).AddTo(disposable);
             graphInputAction.CloseNodeParameter.Subscribe(_ => CurrentInputHandler.CloseNodeParameter()).AddTo(disposable);
             graphInputAction.RemoveNode.Subscribe(x => CurrentInputHandler.RemoveNode(x)).AddTo(disposable);

--- a/Assets/Rector/Scripts/UI/GraphPages/GraphPageInputHandler.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/GraphPageInputHandler.cs
@@ -21,14 +21,6 @@ namespace Rector.UI.GraphPages
         }
 
         /// <summary>
-        /// フォーカスを同じグループ内だけで動かす。directionは上下左右いずれかの単位ベクトル。
-        /// NavModifier(L1/Option)を押しながらの十字キー。
-        /// </summary>
-        public virtual void NavigateInGroup(Vector2Int direction)
-        {
-        }
-
-        /// <summary>
         /// 選択中のノードを隣のグループへ移す。directionは-1か1。GrabModifier(R2/Ctrl)を押しながらの左右。
         /// </summary>
         public virtual void MoveNodeToGroup(int direction)

--- a/Assets/Rector/Scripts/UI/GraphPages/NodeNavigator.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/NodeNavigator.cs
@@ -16,10 +16,10 @@ namespace Rector.UI.GraphPages
         }
 
         /// <remarks>
-        /// フォーカスの移動はグループを跨ぐ。グループ内に閉じるとグループを跨いだ確認がしづらい。
+        /// エッジは辿らず、視覚的な近さだけで行き先が決まる。
         /// 左右はグループ内の行を歩き、グループの端まで来たら隣のグループの最近傍へ入る。
-        /// グループ内に閉じた移動は NavModifier(L1) 側の別経路
-        /// (<see cref="FindHorizontalInSameGroup"/> / <see cref="FindVerticalInSameGroup"/>)。
+        /// 上下はグループ内のレイヤー跨ぎを優先し、グループ内に縦の相手がいないときだけ
+        /// 他グループも含めて近いレイヤーのノードへ移動する。
         /// </remarks>
         public LayeredNode SelectNextNode(LayeredNode current, Vector2 input)
         {
@@ -56,38 +56,17 @@ namespace Rector.UI.GraphPages
                 return FindHorizontalInSameGroup(current, step) ?? current;
             }
 
+            // 上下はまずグループ内のレイヤー跨ぎ。エッジは辿らない(視覚的な近さで行き先が決まる)。
             var up = direction == Direction.Up;
-
-            // REMARK: Parents/Children はSortを実行しないと値が入らない情報なのに注意
-            // Dummy Nodeを加味しているのでOfTypeでフィルタをする必要がある
-            // グループを跨ぐエッジはParents/Childrenに入らないので、まずは同一グループの親子から探す
-            var neighbor = (up ? current.Parents : current.Children)
-                .Select(t => t.Node)
-                .OfType<LayeredNode>()
-                .OrderBy(x => Mathf.Abs(x.TargetPosition.x - current.TargetPosition.x))
-                .FirstOrDefault();
-            if (neighbor != null)
-            {
-                return neighbor;
-            }
-
-            // グループを跨ぐエッジはParents/Childrenに入らないので、生のエッジ列から実の親子を辿る
-            var crossing = FindAcrossGroups(current, up);
-            if (crossing != null)
-            {
-                return crossing;
-            }
-
-            // つながりが無いときは空間的に近いノードへ。まず同グループ内を優先し、
-            // いなければ全グループから探す(上下移動で気づいたら隣のグループに居る事故を防ぐ)。
             var inGroup = FindVerticalInSameGroup(current, up);
             if (inGroup != null)
             {
                 return inGroup;
             }
 
-            // 隣のレイヤーで一番x座標が近いノードに移動する。ノードのないレイヤーは飛ばす。
-            for (var i = 0; i < layers.Count; i++)
+            // グループ内に縦の相手がいなければ、他グループも含めて隣のレイヤーから順に
+            // x座標が一番近いノードへ移動する。ノードのないレイヤーは飛ばす。
+            for (var i = 0; i < layers.Count - 1; i++)
             {
                 currentLayerIndex = (currentLayerIndex + (up ? -1 : 1) + layers.Count) % layers.Count;
                 var candidate = layers[currentLayerIndex]
@@ -107,7 +86,7 @@ namespace Rector.UI.GraphPages
         /// 同じグループ内だけで、同じ行(レイヤー)の隣のノードを返す。グループ内の端まで
         /// 行ったらグループ内の反対端へ回り込む。行内に自分しかいなければnull。
         /// </summary>
-        public LayeredNode FindHorizontalInSameGroup(LayeredNode current, int direction)
+        LayeredNode FindHorizontalInSameGroup(LayeredNode current, int direction)
         {
             var row = graph.Layers[current.Layer];
             var group = groups.Fold(current.Group);
@@ -131,7 +110,7 @@ namespace Rector.UI.GraphPages
         /// いる最初のレイヤーでx座標が一番近いノードを返す。端まで行ったら反対側の端へ
         /// 回り込む。いなければnull。
         /// </summary>
-        public LayeredNode FindVerticalInSameGroup(LayeredNode current, bool up)
+        LayeredNode FindVerticalInSameGroup(LayeredNode current, bool up)
         {
             var layers = graph.Layers;
             var group = groups.Fold(current.Group);
@@ -155,29 +134,6 @@ namespace Rector.UI.GraphPages
             }
 
             return null;
-        }
-
-        LayeredNode FindAcrossGroups(LayeredNode current, bool up)
-        {
-            LayeredNode nearest = null;
-            var nearestDistance = float.MaxValue;
-
-            foreach (var edge in up ? current.EdgesToParent : current.EdgesToChild)
-            {
-                var e = edge.EdgeView.Edge;
-                var nodeId = up ? e.OutputSlot.NodeId : e.InputSlot.NodeId;
-                if (!graph.TryGetNode(nodeId, out var node)) continue;
-                if (groups.Fold(node.Group) == groups.Fold(current.Group)) continue;
-
-                var distance = Mathf.Abs(node.TargetPosition.x - current.TargetPosition.x);
-                if (distance < nearestDistance)
-                {
-                    nearestDistance = distance;
-                    nearest = node;
-                }
-            }
-
-            return nearest;
         }
 
         /// <summary>

--- a/Assets/Rector/Scripts/UI/GraphPages/NodeParameterInputHandler.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/NodeParameterInputHandler.cs
@@ -19,7 +19,7 @@ namespace Rector.UI.GraphPages
         public override void CloseNodeParameter() => view.CloseNodeParameter();
         public override void Cancel() => view.CloseNodeParameter();
 
-        // パネルを開いたままL1を重ねたミュート(MuteChord)がここに届く
+        // パネル表示中のミュート(L1/V)がここに届く
         public override void Mute() => graphPage.ToggleMute(graphPage.SelectedNode);
     }
 }

--- a/Assets/Rector/Scripts/UI/GraphPages/NodeSelectionInputHandler.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/NodeSelectionInputHandler.cs
@@ -39,19 +39,6 @@ namespace Rector.UI.GraphPages
             graphPage.MoveActiveGroup(direction);
         }
 
-        public override void NavigateInGroup(Vector2Int direction)
-        {
-            if (graphPage.SelectedNode is not { } selected) return;
-
-            var next = direction.y != 0
-                ? nodeNavigator.FindVerticalInSameGroup(selected, direction.y > 0)
-                : nodeNavigator.FindHorizontalInSameGroup(selected, direction.x);
-            if (next != null)
-            {
-                graphPage.SelectNode(next);
-            }
-        }
-
         public override void MoveNodeToGroup(int direction)
         {
             graphPage.MoveSelectedNodeToGroup(direction);

--- a/Assets/Rector/Scripts/UI/GraphPages/TargetNodeSelectionInputHandler.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/TargetNodeSelectionInputHandler.cs
@@ -35,19 +35,6 @@ namespace Rector.UI.GraphPages
             }
         }
 
-        public override void NavigateInGroup(Vector2Int direction)
-        {
-            if (graphPage.TargetNode is not { } target) return;
-
-            var next = direction.y != 0
-                ? navigator.FindVerticalInSameGroup(target, direction.y > 0)
-                : navigator.FindHorizontalInSameGroup(target, direction.x);
-            if (next != null)
-            {
-                graphPage.SetTargetNode(next);
-            }
-        }
-
         public override void AddNode()
         {
             graphPage.PromoteTargetToSource();

--- a/Assets/Rector/Settings/RectorInput.inputactions
+++ b/Assets/Rector/Settings/RectorInput.inputactions
@@ -78,15 +78,6 @@
                     "initialStateCheck": false
                 },
                 {
-                    "name": "NavModifier",
-                    "type": "Button",
-                    "id": "80adc06a-a353-4f9f-ba4e-33bf59dcefaa",
-                    "expectedControlType": "",
-                    "processors": "",
-                    "interactions": "",
-                    "initialStateCheck": true
-                },
-                {
                     "name": "GrabModifier",
                     "type": "Button",
                     "id": "42602014-d6ee-4fa8-be7f-5de191d1a6db",
@@ -446,28 +437,6 @@
                 },
                 {
                     "name": "",
-                    "id": "19a43804-cd1c-49c8-bd19-2f5f90f907b1",
-                    "path": "<Gamepad>/leftShoulder",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "",
-                    "action": "NavModifier",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
-                    "id": "c610c862-d97f-4805-9c9a-46c1aa507aca",
-                    "path": "<Keyboard>/alt",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "",
-                    "action": "NavModifier",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
                     "id": "20f8af16-4d2c-48ef-9662-510ea1664d47",
                     "path": "<Gamepad>/rightTrigger",
                     "interactions": "",
@@ -514,6 +483,17 @@
                     "name": "",
                     "id": "d6c9b53e-cdb8-45d5-a10d-19b5fb3223d9",
                     "path": "<Keyboard>/v",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Mute",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "ada450f2-a095-4e98-92b3-8af97af5fa5d",
+                    "path": "<Gamepad>/leftShoulder",
                     "interactions": "",
                     "processors": "",
                     "groups": "",

--- a/Assets/Rector/Tests.meta
+++ b/Assets/Rector/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 686c1a6b42f824685a9c7925bfc7ae3b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Rector/Tests/EditMode.meta
+++ b/Assets/Rector/Tests/EditMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 94a52f19445d54c9f9fadb6d41683fd2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Rector/Tests/EditMode/NodeNavigatorTests.cs
+++ b/Assets/Rector/Tests/EditMode/NodeNavigatorTests.cs
@@ -1,0 +1,234 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Rector.UI.GraphPages;
+using Rector.UI.Graphs;
+using Rector.UI.Graphs.Nodes;
+using Rector.UI.Graphs.Slots;
+using Rector.UI.LayeredGraphDrawing;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Rector.Tests.EditMode
+{
+    /// <summary>
+    /// NodeNavigatorの空間ナビゲーションのテスト。
+    /// GraphSorterは通さず、Sortが保証する不変条件(行はグループ順に連結)を満たす
+    /// Layersを手で組み立てて検証する。
+    /// </summary>
+    public sealed class NodeNavigatorTests
+    {
+        // NodeGroups.PrefsKey と同じ値。SetCountがPlayerPrefsへ書くので退避・復元する
+        const string GroupCountPrefsKey = "Rector_NodeGroupCount";
+        int savedGroupCount;
+
+        [SetUp]
+        public void SetUp() => savedGroupCount = PlayerPrefs.GetInt(GroupCountPrefsKey, NodeGroups.DefaultCount);
+
+        [TearDown]
+        public void TearDown() => PlayerPrefs.SetInt(GroupCountPrefsKey, savedGroupCount);
+
+        static readonly Vector2 Up = Vector2.up;
+        static readonly Vector2 Down = Vector2.down;
+        static readonly Vector2 Left = Vector2.left;
+        static readonly Vector2 Right = Vector2.right;
+
+        sealed class TestNode : Node
+        {
+            public TestNode(uint id) : base(new NodeId(id), $"N{id}")
+            {
+            }
+
+            // 実在しない値にするとNodeViewのアイコン解決がVisualElementFactoryを触らずに済む
+            public override NodeCategory Category => (NodeCategory)(-1);
+            public override InputSlot[] InputSlots => Array.Empty<InputSlot>();
+            public override OutputSlot[] OutputSlots => Array.Empty<OutputSlot>();
+        }
+
+        // NodeView.uxmlと同じ名前の要素だけを持つ最小のツリー
+        static VisualElement CreateNodeTemplate()
+        {
+            var container = new VisualElement();
+            var node = new VisualElement { name = "node" };
+            node.Add(new Label { name = "name-label" });
+            node.Add(new VisualElement { name = "input-slot-list" });
+            node.Add(new VisualElement { name = "output-slot-list" });
+            node.Add(new VisualElement { name = "icon" });
+            container.Add(node);
+            return container;
+        }
+
+        static uint nextId;
+
+        static LayeredNode CreateNode(int group, int layer, float x)
+        {
+            var view = new NodeView(CreateNodeTemplate(), new TestNode(nextId++));
+            // Positionのsetterが、ナビゲーションの基準になるTargetPositionも確定させる
+            view.Position = new Vector2(x, layer * 100f);
+            return new LayeredNode(view) { Group = group, Layer = layer };
+        }
+
+        static LayeredGraph CreateGraph(params ILayeredNode[][] rows)
+        {
+            var graph = new LayeredGraph(new VisualElement(), new VisualElement());
+            graph.Layers.Clear();
+            foreach (var row in rows)
+            {
+                var list = new List<ILayeredNode>();
+                foreach (var node in row)
+                {
+                    node.Index = list.Count;
+                    list.Add(node);
+                }
+
+                graph.Layers.Add(list);
+            }
+
+            return graph;
+        }
+
+        static NodeGroups CreateGroups(int count)
+        {
+            var groups = new NodeGroups();
+            groups.SetCount(count);
+            return groups;
+        }
+
+        // issue-52の議論で使った基本形:
+        //   A | B | D     A,C=グループ0 / B=グループ1 / D=グループ2
+        //     | B |       レイヤーは A,D=0 / B=1 / C=2
+        //   C |   |
+        (NodeNavigator navigator, LayeredNode a, LayeredNode b, LayeredNode c, LayeredNode d) CreateKanbanFixture()
+        {
+            var groups = CreateGroups(3);
+            var a = CreateNode(0, 0, 0f);
+            var d = CreateNode(2, 0, 520f);
+            var b = CreateNode(1, 1, 200f);
+            var c = CreateNode(0, 2, 0f);
+            var graph = CreateGraph(
+                new ILayeredNode[] { a, d },
+                new ILayeredNode[] { b },
+                new ILayeredNode[] { c });
+            return (new NodeNavigator(graph, groups), a, b, c, d);
+        }
+
+        [Test]
+        public void Vertical_StaysInGroup_SkippingOtherGroupsBetweenLayers()
+        {
+            var (navigator, a, _, c, _) = CreateKanbanFixture();
+
+            // AとCの間のレイヤーには別グループのBがいるが、上下はグループ内に閉じる
+            Assert.That(navigator.SelectNextNode(a, Down), Is.SameAs(c));
+            Assert.That(navigator.SelectNextNode(c, Up), Is.SameAs(a));
+        }
+
+        [Test]
+        public void Vertical_WrapsWithinGroup()
+        {
+            var (navigator, a, _, c, _) = CreateKanbanFixture();
+
+            Assert.That(navigator.SelectNextNode(c, Down), Is.SameAs(a));
+            Assert.That(navigator.SelectNextNode(a, Up), Is.SameAs(c));
+        }
+
+        [Test]
+        public void Vertical_AloneInGroup_FallsBackToNearestAcrossGroups()
+        {
+            var (navigator, a, b, c, d) = CreateKanbanFixture();
+
+            // B(グループ1で唯一)の上下は他グループへ: 上はxが近いA、下はC
+            Assert.That(navigator.SelectNextNode(b, Up), Is.SameAs(a));
+            Assert.That(navigator.SelectNextNode(b, Down), Is.SameAs(c));
+            // D(グループ2で唯一)の下は隣レイヤーのB
+            Assert.That(navigator.SelectNextNode(d, Down), Is.SameAs(b));
+        }
+
+        [Test]
+        public void Vertical_NoCandidateAnywhere_StaysPut()
+        {
+            var groups = CreateGroups(1);
+            var a = CreateNode(0, 0, 0f);
+            var graph = CreateGraph(new ILayeredNode[] { a });
+            var navigator = new NodeNavigator(graph, groups);
+
+            Assert.That(navigator.SelectNextNode(a, Down), Is.SameAs(a));
+            Assert.That(navigator.SelectNextNode(a, Up), Is.SameAs(a));
+        }
+
+        [Test]
+        public void Horizontal_WalksRowWithinGroup()
+        {
+            var groups = CreateGroups(1);
+            var a = CreateNode(0, 0, 0f);
+            var e = CreateNode(0, 0, 100f);
+            var graph = CreateGraph(new ILayeredNode[] { a, e });
+            var navigator = new NodeNavigator(graph, groups);
+
+            Assert.That(navigator.SelectNextNode(a, Right), Is.SameAs(e));
+            Assert.That(navigator.SelectNextNode(e, Left), Is.SameAs(a));
+        }
+
+        [Test]
+        public void Horizontal_AtGroupEdge_EntersAdjacentGroupAtNearestNode()
+        {
+            var (navigator, a, b, _, d) = CreateKanbanFixture();
+
+            // Aの行(レイヤー0)の右隣は行としてはDだが、まず隣のグループ1の最近傍Bに入る
+            Assert.That(navigator.SelectNextNode(a, Right), Is.SameAs(b));
+            Assert.That(navigator.SelectNextNode(b, Right), Is.SameAs(d));
+        }
+
+        [Test]
+        public void Horizontal_WrapsAcrossGroups()
+        {
+            var (navigator, a, _, _, d) = CreateKanbanFixture();
+
+            // 右端グループから右はグループ0へ戻る。レイヤーが近いAが選ばれる(Cではなく)
+            Assert.That(navigator.SelectNextNode(d, Right), Is.SameAs(a));
+            // 左端グループから左はグループ2へ回り込む
+            Assert.That(navigator.SelectNextNode(a, Left), Is.SameAs(d));
+        }
+
+        [Test]
+        public void Horizontal_SingleGroup_WrapsWithinRow()
+        {
+            var groups = CreateGroups(1);
+            var a = CreateNode(0, 0, 0f);
+            var e = CreateNode(0, 0, 100f);
+            var graph = CreateGraph(new ILayeredNode[] { a, e });
+            var navigator = new NodeNavigator(graph, groups);
+
+            Assert.That(navigator.SelectNextNode(e, Right), Is.SameAs(a));
+            Assert.That(navigator.SelectNextNode(a, Left), Is.SameAs(e));
+        }
+
+        [Test]
+        public void Horizontal_SkipsDummyNodes()
+        {
+            var groups = CreateGroups(1);
+            var a = CreateNode(0, 0, 0f);
+            var dummy = new DummyNode(new NodeId(9999)) { Group = 0, Layer = 0 };
+            var e = CreateNode(0, 0, 100f);
+            var graph = CreateGraph(new ILayeredNode[] { a, dummy, e });
+            var navigator = new NodeNavigator(graph, groups);
+
+            Assert.That(navigator.SelectNextNode(a, Right), Is.SameAs(e));
+            Assert.That(navigator.SelectNextNode(e, Left), Is.SameAs(a));
+        }
+
+        [Test]
+        public void FindNodeInAdjacentGroup_SkipsEmptyGroupsAndWraps()
+        {
+            var groups = CreateGroups(3);
+            var a = CreateNode(0, 0, 0f);
+            var d = CreateNode(2, 0, 520f);
+            var graph = CreateGraph(new ILayeredNode[] { a, d });
+            var navigator = new NodeNavigator(graph, groups);
+
+            // グループ1は空なのでスキップされ、右隣はグループ2のD
+            Assert.That(navigator.FindNodeInAdjacentGroup(a, 1, groups.CurrentCount), Is.SameAs(d));
+            // 右端からはグループ0へラップ
+            Assert.That(navigator.FindNodeInAdjacentGroup(d, 1, groups.CurrentCount), Is.SameAs(a));
+        }
+    }
+}

--- a/Assets/Rector/Tests/EditMode/NodeNavigatorTests.cs.meta
+++ b/Assets/Rector/Tests/EditMode/NodeNavigatorTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a5bc89af4ffb54a6b8ff483fcc1c3e12

--- a/Assets/Rector/Tests/EditMode/Rector.Tests.EditMode.asmdef
+++ b/Assets/Rector/Tests/EditMode/Rector.Tests.EditMode.asmdef
@@ -1,0 +1,26 @@
+{
+    "name": "Rector.Tests.EditMode",
+    "rootNamespace": "",
+    "references": [
+        "Rector",
+        "R3.Unity",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll",
+        "R3.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Rector/Tests/EditMode/Rector.Tests.EditMode.asmdef.meta
+++ b/Assets/Rector/Tests/EditMode/Rector.Tests.EditMode.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b52280b2e21164de4836ffb529126ba0
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

Play feedback on the #51 modifier grammar (#52). The direction is simplification: navigation is decided purely by visual proximity, and the group columns become the vertical structure.

| Input | Meaning |
|---|---|
| D-pad up/down | **Cross layers within the current group first**; only when the group has no vertical neighbor, fall back to the nearest node on adjacent layers across groups. Edge-following is gone |
| D-pad left/right | Walk the row within the group, enter the adjacent group at its nearest node at the boundary (unchanged from #51) |
| **L1** | **Mute toggle (single press)** — the in-group navigation chord and L1+R1 chord are removed |
| R2 + left/right | Move the selected node to the adjacent group (unchanged) |
| **L2 / Tab hold** | Camera lock: **captures the focused node's screen position on press** and keeps the focus node there while held. No more centering jump |

Keyboard: V stays as mute; Alt is intentionally left unbound (a bare modifier key firing mute would be an accidental-mute trap). Q/E group jump and U/O zoom unchanged.

## Details

- `RectorInput.inputactions`: removed the `NavModifier` action, bound `<Gamepad>/leftShoulder` to `Mute`. `RectorInput.cs` regenerated
- `GraphInputAction`: chord machinery is grab-only now; `MuteChord`/`NavigateInGroup`/`IsLockHeld` and the R1 open-suppression are gone. `Lock` now emits `LockEnded` on release
- `NodeNavigator.SelectNextNode` up/down: 2-pass — `FindVerticalInSameGroup` (wraps within the group) then the adjacent-layer nearest-x scan across groups (own layer excluded). The `Parents`/`Children`/`FindAcrossGroups` edge-following paths are deleted
- `GraphContentTransformer`: anchor-based lock follow. `BeginLockFollow` captures `translation + node.TargetPosition * scale` (no movement on press; deferred arming when pressed with no focus); focus changes place the new node at the anchor; manual pan shifts the anchor, zoom and reset re-derive it so nothing snaps; a re-layout while locked keeps the focus node pinned
- `GraphPage`: lock press/release now just arms/disarms the transformer; mute reaches every state's handler again (target-state gating removed with the chord)
- **New: first EditMode test assembly** `Assets/Rector/Tests/EditMode/` — `NodeNavigatorTests` builds `Layers` by hand (no sorter, no UI layout) and covers: in-group vertical priority and wrap, the cross-group fallback using the exact acceptance example from the issue (`B↑→A`, `B↓→C`, `D↓→B`), boundary hop, cross-group wrap, dummy-node skipping, and empty-group skipping

## Test plan

- [x] `unity command recompile` clean after all changes, no console errors, no stale references to removed APIs
- [x] EditMode tests: 9/9 passed before the final up/down fallback revision
- [x] EditMode tests: 10/10 passed after the fallback revision (verified after an editor restart)
- [x] Play-mode numeric verification of the lock anchor (no jump on press, anchor and follow math)
- [ ] Gamepad feel: L1 mute, up/down group-priority movement, lock hold behavior

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)