### PR TITLE
chore: update LASP to 2.1.8 and bump other packages

### DIFF
--- a/Assets/packages.config
+++ b/Assets/packages.config
@@ -15,7 +15,7 @@
   <package id="Microsoft.Extensions.Primitives" version="8.0.0" />
   <package id="ModelContextProtocol" version="0.3.0-preview.2" manuallyInstalled="true" />
   <package id="ModelContextProtocol.Core" version="0.3.0-preview.2" />
-  <package id="R3" version="1.2.9" manuallyInstalled="true" />
+  <package id="R3" version="1.3.1" manuallyInstalled="true" />
   <package id="System.ComponentModel.Annotations" version="5.0.0" />
   <package id="System.Diagnostics.DiagnosticSource" version="8.0.1" />
   <package id="System.IO.Pipelines" version="9.0.6" />
@@ -24,6 +24,6 @@
   <package id="System.Text.Encodings.Web" version="9.0.6" />
   <package id="System.Text.Json" version="9.0.6" manuallyInstalled="true" />
   <package id="System.Threading.Channels" version="8.0.0" />
-  <package id="VYaml" version="1.0.0" manuallyInstalled="true" />
-  <package id="VYaml.Annotations" version="1.0.0" />
+  <package id="VYaml" version="1.4.0" manuallyInstalled="true" />
+  <package id="VYaml.Annotations" version="1.4.0" />
 </packages>

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
-    "com.cysharp.r3": "https://github.com/Cysharp/R3.git?path=src/R3.Unity/Assets/R3.Unity#1.3.0",
-    "com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask#2.5.10",
-    "com.github-glitchenzo.nugetforunity": "https://github.com/GlitchEnzo/NuGetForUnity.git?path=/src/NuGetForUnity#v4.3.0",
+    "com.cysharp.r3": "https://github.com/Cysharp/R3.git?path=src/R3.Unity/Assets/R3.Unity#1.3.1",
+    "com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask#2.5.11",
+    "com.github-glitchenzo.nugetforunity": "https://github.com/GlitchEnzo/NuGetForUnity.git?path=/src/NuGetForUnity#v4.5.0",
     "com.unity.cinemachine": "3.1.7",
     "com.unity.ide.rider": "3.0.40",
     "com.unity.ide.visualstudio": "2.0.27",
@@ -11,8 +11,8 @@
     "com.unity.render-pipelines.universal": "17.1.0",
     "com.unity.test-framework": "1.5.1",
     "com.unity.visualeffectgraph": "17.1.0",
-    "jp.hadashikick.vyaml": "https://github.com/hadashiA/VYaml.git?path=VYaml.Unity/Assets/VYaml#1.0.0",
-    "jp.keijiro.lasp": "https://github.com/keijiro/Lasp.git?path=Packages/jp.keijiro.lasp#v2",
+    "jp.hadashikick.vyaml": "https://github.com/hadashiA/VYaml.git?path=VYaml.Unity/Assets/VYaml#1.4.0",
+    "jp.keijiro.lasp": "https://github.com/keijiro/Lasp.git?path=Packages/jp.keijiro.lasp#2.1.8",
     "com.unity.modules.accessibility": "1.0.0",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,27 +1,27 @@
 {
   "dependencies": {
     "com.cysharp.r3": {
-      "version": "https://github.com/Cysharp/R3.git?path=src/R3.Unity/Assets/R3.Unity#1.3.0",
+      "version": "https://github.com/Cysharp/R3.git?path=src/R3.Unity/Assets/R3.Unity#1.3.1",
       "depth": 0,
       "source": "git",
       "dependencies": {
         "com.unity.modules.imgui": "1.0.0"
       },
-      "hash": "329ca7915713417f2e0837b0e0a80b4da074db4a"
+      "hash": "f6eed2dd4208dc4ae171c601e799e85f82aca25e"
     },
     "com.cysharp.unitask": {
-      "version": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask#2.5.10",
+      "version": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask#2.5.11",
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "7c0f199fe0d3fc528024488ccd671e6c7b27745b"
+      "hash": "2e993ff18f28c931602a07292df0b0804eebef99"
     },
     "com.github-glitchenzo.nugetforunity": {
-      "version": "https://github.com/GlitchEnzo/NuGetForUnity.git?path=/src/NuGetForUnity#v4.3.0",
+      "version": "https://github.com/GlitchEnzo/NuGetForUnity.git?path=/src/NuGetForUnity#v4.5.0",
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "36d3260fdca03bf6feb105c67022d1fd7629dd2f"
+      "hash": "a7c6b49a0141a5bff9b1983e38137522ef61977d"
     },
     "com.unity.burst": {
       "version": "1.8.30",
@@ -229,24 +229,24 @@
       }
     },
     "jp.hadashikick.vyaml": {
-      "version": "https://github.com/hadashiA/VYaml.git?path=VYaml.Unity/Assets/VYaml#1.0.0",
+      "version": "https://github.com/hadashiA/VYaml.git?path=VYaml.Unity/Assets/VYaml#1.4.0",
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "56404f2d503d841a0ad3429eedd00bfe7921f680"
+      "hash": "cad0608ed716a0367d2fc31b0804405d6ec80fb8"
     },
     "jp.keijiro.lasp": {
-      "version": "https://github.com/keijiro/Lasp.git?path=Packages/jp.keijiro.lasp#v2",
+      "version": "https://github.com/keijiro/Lasp.git?path=Packages/jp.keijiro.lasp#2.1.8",
       "depth": 0,
       "source": "git",
       "dependencies": {
         "com.unity.burst": "1.4.4",
-        "jp.keijiro.libsoundio": "1.0.5"
+        "jp.keijiro.libsoundio": "1.0.6"
       },
-      "hash": "d0445d6d37db7c8402b10261bd286cef50e07428"
+      "hash": "b57e37fbb07f4492dd9b71defd29c9250e131280"
     },
     "jp.keijiro.libsoundio": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "depth": 1,
       "source": "registry",
       "dependencies": {},


### PR DESCRIPTION
Closes #59

## What

| Package | Before | After | Notes |
|---|---|---|---|
| jp.keijiro.lasp (UPM git) | 2.1.7 (`#v2` branch) | **2.1.8** (`#2.1.8` tag) | Pulls in the macOS Tahoe fix; also switched from branch tracking to a pinned tag, matching the other git packages |
| jp.keijiro.libsoundio (registry) | 1.0.5 | 1.0.6 | Indirect dependency of LASP — this is the actual Tahoe fix ("libsoundio version update (fix for macOS Tahoe)") |
| com.cysharp.unitask (UPM git) | 2.5.10 | 2.5.11 | Patch |
| com.cysharp.r3 (UPM git) | 1.3.0 | 1.3.1 | Patch |
| R3 (NuGet) | 1.2.9 | 1.3.1 | Also aligns the NuGet core dll with the UPM R3.Unity version (they were mismatched) |
| VYaml / VYaml.Annotations (NuGet) + jp.hadashikick.vyaml (UPM git) | 1.0.0 | 1.4.0 | Bug fixes and optimizations only; no breaking API changes per release notes |
| com.github-glitchenzo.nugetforunity (UPM git) | v4.3.0 | v4.5.0 | Editor tooling |

Already at latest, unchanged: Cinemachine 3.1.7, Input System 1.20.0, Rider 3.0.40, Visual Studio 2.0.27. Built-in packages (URP / VFX Graph / test framework, etc.) are tied to the editor version and out of scope.

## Verification

- Unity 6000.3.21f1 batchmode import + script compile on the worktree: 0 compiler errors
- `packages-lock.json` re-resolved by Unity (not hand-edited): LASP hash `b57e37f` (= tag 2.1.8), libsoundio 1.0.6
- EditMode tests: 10/10 passed
- Runtime audio-input check on macOS Tahoe (the point of the LASP fix) still needs a manual pass in the editor or a build

🤖 Generated with [Claude Code](https://claude.com/claude-code)