### PR TITLE
fix: make the font atlas texture readable again

### DIFF
--- a/Assets/Rector/StaticResources/FontAssets/JetBrains_Mono/JetBrainsMono-Thin_SDF.asset
+++ b/Assets/Rector/StaticResources/FontAssets/JetBrains_Mono/JetBrainsMono-Thin_SDF.asset
@@ -2817,7 +2817,7 @@ Texture2D:
   m_MipsStripped: 0
   m_TextureFormat: 1
   m_MipCount: 1
-  m_IsReadable: 0
+  m_IsReadable: 1
   m_IsPreProcessed: 0
   m_IgnoreMipmapLimit: 1
   m_MipmapLimitGroupName: 


### PR DESCRIPTION
## Summary

Follow-up to #63. The static rebake left the atlas texture with `m_IsReadable: 0` — correct for a static atlas, wrong for a dynamic one. After #63 restored dynamic population, any glyph outside the seed set failed at runtime:

```
Unable to add the requested glyph to font asset [JetBrainsMono-Thin_SDF]'s atlas texture.
Please make the texture [JetBrainsMono-Thin_SDF Atlas] readable.
```

One-line fix: `m_IsReadable: 0` → `1` (matches what the asset had before #63).

## Test plan

- [x] EditMode tests 10/10
- [x] Verified in the editor: population mode Dynamic, `atlasTextures[0].isReadable == true`, seed set intact at 102 chars
- [x] `TryAddCharacters("Paweł")` now succeeds where it previously failed (the drift glyph was then reverted so the committed diff is the readable flag only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)