### PR TITLE
change: keep the slot direction when CONTINUE promotes the target to source

### DIFF
--- a/Assets/Rector/Scripts/UI/GraphPages/GraphPage.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/GraphPage.cs
@@ -357,10 +357,14 @@ namespace Rector.UI.GraphPages
         /// <summary>
         /// ターゲットをソースに引き継いでスロット選択へ移る。ターゲット選択中の△/Cで、
         /// ソース選択まで戻らずに、いま指しているノードから続けて次のエッジを張るための操作。
+        /// 昇格後のスロットは昇格前のソーススロットと同じ向きに揃える。A.out→B.inと繋いだ流れなら
+        /// 昇格後もoutputを指すので、B→CをCONTINUEの連打だけで伸ばせる。
         /// </summary>
         /// <remarks>
         /// Target系のクリアはセッターを通さない。SetTargetNode(null)は旧SelectedNodeへ視点を
         /// 戻してしまうため。代わりにIsTargetはここで明示的に降ろす(降ろし忘れると表示が残留する)。
+        /// 途中で抜けるとIsTargetが残留するので、早期returnは状態を書き換える前に済ませること。
+        /// 向きの読み取りもSelectSlotより前に。SelectSlotは旧SelectedSlotを潰す。
         /// </remarks>
         public void PromoteTargetToSource()
         {
@@ -370,25 +374,31 @@ namespace Rector.UI.GraphPages
                     {
                         // CLIからStateを直接動かされた場合に備えてnullを弾く
                         if (TargetNode is not { } target) return;
-                        if (target.InputSlotCount == 0 && target.OutputSlotCount == 0) return;
+                        var node = target.NodeView.Node;
+                        // SelectedSlotが無いのもCLI経由の異常系。従来通りinput優先に倒す
+                        var direction = SelectedSlot?.Direction ?? SlotDirection.Input;
+                        if (SlotNavigator.PickInDirection(direction, node.InputSlots, node.OutputSlots) is not { } next) return;
 
-                        target.NodeView.Node.IsTarget.Value = false;
+                        node.IsTarget.Value = false;
                         TargetNode = null;
                         SelectNode(target);
-                        SelectSlot(target.InputSlotCount > 0 ? target.NodeView.Node.InputSlots[0] : target.NodeView.Node.OutputSlots[0]);
+                        SelectSlot(next);
                         State.Value = GraphPageState.SlotSelection;
                         break;
                     }
                 case GraphPageState.TargetSlotSelection:
                     {
                         if (TargetNode is not { } target || TargetSlot is not { } targetSlot) return;
+                        var node = target.NodeView.Node;
+                        var direction = SelectedSlot?.Direction ?? targetSlot.Direction;
+                        var next = SlotNavigator.PickInDirection(direction, node.InputSlots, node.OutputSlots) ?? targetSlot;
 
-                        target.NodeView.Node.IsTarget.Value = false;
+                        node.IsTarget.Value = false;
                         targetSlot.IsTarget.Value = false;
                         TargetNode = null;
                         TargetSlot = null;
                         SelectNode(target);
-                        SelectSlot(targetSlot);
+                        SelectSlot(next);
                         State.Value = GraphPageState.SlotSelection;
                         break;
                     }

--- a/Assets/Rector/Scripts/UI/GraphPages/SlotNavigator.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/SlotNavigator.cs
@@ -1,0 +1,26 @@
+using Rector.UI.Graphs.Slots;
+
+#nullable enable
+
+namespace Rector.UI.GraphPages
+{
+    /// <summary>スロット選択のカーソル移動先を決める。ビューに触らない純粋な計算のみ。</summary>
+    public static class SlotNavigator
+    {
+        /// <summary>
+        /// 指定した向きのスロットの先頭を返す。その向きが空なら反対側の先頭に落とし、
+        /// どちらも空なら null。
+        /// </summary>
+        public static ISlot? PickInDirection(SlotDirection direction, InputSlot[] inputSlots, OutputSlot[] outputSlots)
+        {
+            if (direction == SlotDirection.Output)
+            {
+                if (outputSlots.Length > 0) return outputSlots[0];
+                return inputSlots.Length > 0 ? inputSlots[0] : null;
+            }
+
+            if (inputSlots.Length > 0) return inputSlots[0];
+            return outputSlots.Length > 0 ? outputSlots[0] : null;
+        }
+    }
+}

--- a/Assets/Rector/Scripts/UI/GraphPages/SlotNavigator.cs.meta
+++ b/Assets/Rector/Scripts/UI/GraphPages/SlotNavigator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 93ed409301b2c4e5a848f6f32f74c12e

--- a/Assets/Rector/Tests/EditMode/SlotNavigatorTests.cs
+++ b/Assets/Rector/Tests/EditMode/SlotNavigatorTests.cs
@@ -1,0 +1,100 @@
+using System;
+using NUnit.Framework;
+using R3;
+using Rector.UI.GraphPages;
+using Rector.UI.Graphs;
+using Rector.UI.Graphs.Slots;
+
+namespace Rector.Tests.EditMode
+{
+    /// <summary>
+    /// SlotNavigatorのカーソル移動先決定のテスト。ビュー非依存なので、スロットだけ手で並べて検証する。
+    /// </summary>
+    public sealed class SlotNavigatorTests
+    {
+        sealed class TestInputSlot : InputSlot<Unit>
+        {
+            public TestInputSlot(int index) : base(new NodeId(0), index, $"in{index}")
+            {
+            }
+
+            public override void Send(Unit value)
+            {
+            }
+
+            public override Observable<Unit> Observable() => R3.Observable.Empty<Unit>();
+        }
+
+        sealed class TestOutputSlot : OutputSlot<Unit>
+        {
+            public TestOutputSlot(int index) : base(new NodeId(0), index, $"out{index}")
+            {
+            }
+
+            public override Observable<Unit> Observable() => R3.Observable.Empty<Unit>();
+        }
+
+        static InputSlot[] Inputs(int count)
+        {
+            var slots = new InputSlot[count];
+            for (var i = 0; i < count; i++) slots[i] = new TestInputSlot(i);
+            return slots;
+        }
+
+        static OutputSlot[] Outputs(int count)
+        {
+            var slots = new OutputSlot[count];
+            for (var i = 0; i < count; i++) slots[i] = new TestOutputSlot(i);
+            return slots;
+        }
+
+        [Test]
+        public void PickInDirection_Output_ReturnsFirstOutput()
+        {
+            var inputs = Inputs(3);
+            var outputs = Outputs(2);
+
+            var slot = SlotNavigator.PickInDirection(SlotDirection.Output, inputs, outputs);
+
+            Assert.That(slot, Is.SameAs(outputs[0]));
+        }
+
+        [Test]
+        public void PickInDirection_Input_ReturnsFirstInput()
+        {
+            var inputs = Inputs(3);
+            var outputs = Outputs(2);
+
+            var slot = SlotNavigator.PickInDirection(SlotDirection.Input, inputs, outputs);
+
+            Assert.That(slot, Is.SameAs(inputs[0]));
+        }
+
+        [Test]
+        public void PickInDirection_OutputWithNoOutputs_FallsBackToInput()
+        {
+            var inputs = Inputs(2);
+
+            var slot = SlotNavigator.PickInDirection(SlotDirection.Output, inputs, Array.Empty<OutputSlot>());
+
+            Assert.That(slot, Is.SameAs(inputs[0]));
+        }
+
+        [Test]
+        public void PickInDirection_InputWithNoInputs_FallsBackToOutput()
+        {
+            var outputs = Outputs(2);
+
+            var slot = SlotNavigator.PickInDirection(SlotDirection.Input, Array.Empty<InputSlot>(), outputs);
+
+            Assert.That(slot, Is.SameAs(outputs[0]));
+        }
+
+        [Test]
+        public void PickInDirection_NoSlots_ReturnsNull()
+        {
+            Assert.That(SlotNavigator.PickInDirection(SlotDirection.Output, Array.Empty<InputSlot>(), Array.Empty<OutputSlot>()), Is.Null);
+            Assert.That(SlotNavigator.PickInDirection(SlotDirection.Input, Array.Empty<InputSlot>(), Array.Empty<OutputSlot>()), Is.Null);
+        }
+    }
+}

--- a/Assets/Rector/Tests/EditMode/SlotNavigatorTests.cs.meta
+++ b/Assets/Rector/Tests/EditMode/SlotNavigatorTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 75822a07e9bb341afabf7f4d35a2839d


### PR DESCRIPTION
Closes #67

## 背景

CONTINUE（ターゲットノードをソースに昇格させる操作）は、ターゲットスロットをそのまま選択スロットにしていた。そのため A.out -> B.in を繋いだ直後に CONTINUE すると、カーソルが B.in に残る。A -> B -> C と鎖状に繋いでいくには、毎回スロットを output 側に戻す必要があった。

## 変更

昇格前のソーススロットの向きを引き継ぐようにした。output スロットから昇格したならターゲットの先頭 output、input スロットからなら先頭 input に乗る。その向きのスロットを持たないノードの場合は反対側にフォールバックする。

`TargetNodeSelection` / `TargetSlotSelection` の両経路を同じ規則に揃えた。従来 `TargetNodeSelection` 側は input 優先の固定だったため、経路によって挙動が違っていた。

スロット選択のロジックは `SlotNavigator` に切り出し、Unity 依存の `GraphPage` を組み立てずに単体テストできるようにした。

## 確認

- `unity command recompile` → エラーなし
- `unity command run_tests` → EditMode 15/15 passed
- Play モードで `PromoteTargetToSource` を直接叩いて確認:

| ケース | 昇格前のソース | 昇格後 |
|---|---|---|
| TargetSlotSelection | Time.`time` (Output) | Negate.`Out` (Output) |
| TargetSlotSelection | Time.`Active` (Input) | Negate.`In` (Input) |
| TargetNodeSelection | Time.`frac` (Output) | Negate.`Out` (Output) |
| TargetNodeSelection | Time.`scale` (Input) | Negate.`In` (Input) |
| output を持たないノードへ | Time.`time` (Output) | Ring.`Active` (Input にフォールバック) |

いずれも `IsTarget` の残留はなく、State は `SlotSelection` に遷移する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Lr4QLehUVwNbyHwbC4guS