### PR TITLE
fix: close scenes that the build pipeline leaves open

### DIFF
--- a/Assets/Rector/Scripts/Editor/BuildSceneSetupRestorer.cs
+++ b/Assets/Rector/Scripts/Editor/BuildSceneSetupRestorer.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor.Build;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace Rector.Editor
+{
+    /// <summary>
+    /// ビルド前後で Hierarchy のシーン構成を保つ。
+    ///
+    /// com.unity.pipeline (0.4.0-exp.1) の PipelineRuntimeBuildProcessor は、ビルド前処理で
+    /// RuntimePipelineManager を探すために Build Settings の全シーンを Additive で開くが、
+    /// 一度も閉じない。そのためエディタでビルドすると Base / Room / White が Hierarchy に
+    /// 開きっぱなしになり、手で unload する必要がある (issue #64)。
+    /// PackageCache は再取得で書き戻されるので、こちら側で後始末する。
+    ///
+    /// ビルドが失敗すると後処理が呼ばれないため、そのケースでは開いたままになる。
+    /// 未保存の Untitled シーンしか開いていない場合はスナップショットが空になるので何もしない。
+    /// </summary>
+    public sealed class BuildSceneSetupRestorer : IPreprocessBuildWithContext, IPostprocessBuildWithContext
+    {
+        // スナップショットは PipelineRuntimeBuildProcessor (callbackOrder = 0) が
+        // シーンを開く前に取る必要がある。Unity 6000.3 ではあちらも
+        // IPreprocessBuildWithContext を実装するので、同一インターフェイス内での
+        // callbackOrder の順序保証だけに頼ればよい。
+        public int callbackOrder => int.MinValue;
+
+        static SceneSetup[] setupBeforeBuild;
+
+        public void OnPreprocessBuild(BuildCallbackContext context)
+        {
+            setupBeforeBuild = EditorSceneManager.GetSceneManagerSetup();
+        }
+
+        public void OnPostprocessBuild(BuildCallbackContext context)
+        {
+            var setup = setupBeforeBuild;
+            setupBeforeBuild = null;
+            if (setup == null || setup.Length == 0) return;
+
+            var before = new Dictionary<string, SceneSetup>();
+            foreach (var s in setup)
+            {
+                before[s.path] = s;
+            }
+
+            // 元から開いていたシーンには触らない。開き直すと未保存の変更やエディタの
+            // 状態が飛ぶので、ビルドが開いたものだけを閉じる。
+            var closed = new List<string>();
+            for (var i = SceneManager.sceneCount - 1; i >= 0; i--)
+            {
+                var scene = SceneManager.GetSceneAt(i);
+                // path は閉じたあとには読めなくなるので先に控える。
+                var path = scene.path;
+                if (!before.TryGetValue(path, out var s))
+                {
+                    EditorSceneManager.CloseScene(scene, true);
+                    closed.Add(path);
+                }
+                else if (scene.isLoaded && !s.isLoaded)
+                {
+                    // Hierarchy には並んでいたが unload されていた状態に戻す。
+                    EditorSceneManager.CloseScene(scene, false);
+                    closed.Add(path);
+                }
+            }
+
+            if (closed.Count == 0) return;
+
+            // Additive で開かれた影響でアクティブシーンが変わっていることがある。
+            var active = setup.FirstOrDefault(s => s.isActive);
+            if (active != null)
+            {
+                var scene = SceneManager.GetSceneByPath(active.path);
+                if (scene.IsValid() && scene.isLoaded)
+                {
+                    EditorSceneManager.SetActiveScene(scene);
+                }
+            }
+
+            Debug.Log($"Closed {closed.Count} scene(s) opened by the build: {string.Join(", ", closed)}");
+        }
+    }
+}

--- a/Assets/Rector/Scripts/Editor/BuildSceneSetupRestorer.cs.meta
+++ b/Assets/Rector/Scripts/Editor/BuildSceneSetupRestorer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 64721810e78be410ba465a83bc398360


### PR DESCRIPTION
Fixes #64

## 原因

`com.unity.pipeline@0.4.0-exp.1` の `PipelineRuntimeBuildProcessor.OnPreprocessBuild` が、`RuntimePipelineManager` を探すために Build Settings の全シーンを `OpenSceneMode.Additive` で開いたまま閉じていない。そのためエディタでビルドすると Base / Room / White が Hierarchy に開きっぱなしになり、毎回手で unload する必要があった。

該当箇所: `Library/PackageCache/com.unity.pipeline@.../Editor/BuildProcessors/PipelineRuntimeBuildProcessor.cs` の `FindRuntimeManagersInBuildScenes()`。直前のコメントには "this opens and closes scene" とあるが、close していない。

## 変更

PackageCache は再取得で書き戻されるため、Rector 側で後始末する Editor スクリプトを追加した。

- ビルド前に `EditorSceneManager.GetSceneManagerSetup()` でシーン構成を記録（`callbackOrder = int.MinValue` でパッケージ側の `0` より先に走る）
- ビルド後に、ビルドが開いたシーンだけを `CloseScene` する。元から開いていたシーンには触らないので、未保存の変更やエディタの状態は失われない
- アクティブシーンも元に戻す

ビルドが失敗した場合は後処理が呼ばれないため、従来どおり開いたままになる。

## 動作確認

- batchmode でコンパイル確認（`error CS` なし）
- StandaloneOSX の実ビルドを1回完走（`result=Succeeded`, 6分11秒）
  - ビルド前: Base のみ → ビルド後: Base のみ（アクティブも Base）
  - ログに `Closed 2 scene(s) opened by the build:` が出力され、Room / White が閉じられたことを確認

なお、この検証ビルドの時点ではログのパス表示にバグがあり（閉じたあとに `scene.path` を読んでいて空文字になる）、行末のパスが空で出力されていた。その後パスを閉じる前に控えるよう修正し、コンパイル確認まで実施済み。閉じる処理自体は検証時のコードから変わっていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)