### PR TITLE
fix: do not relaunch Unity when the project is already open

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,21 @@ require-unity:
 		exit 1; \
 	}
 
+# `unity open` は既存インスタンスを見ずに毎回新しい Unity を起動するので、
+# すでに開いていると Unity 本体が二重起動を拒否してエラーになる。開いているかは
+# こちらで見て、開いていればウィンドウを前面に出すだけにする。
+# なお複数のエディタが起動している場合、open -a はアプリを前面に出すだけで
+# どのプロジェクトのウィンドウが来るかは選べない。
 unity: require-unity ## Unity エディタでプロジェクトを開く
-	$(UNITY) open
+	@pid=$$($(UNITY) status --format tsv 2>/dev/null \
+		| awk -F'\t' -v p="$(CURDIR)" '$$3 == p { print $$5; exit }'); \
+	if [ -n "$$pid" ]; then \
+		app=$$($(UNITY) editors --format tsv 2>/dev/null \
+			| awk -F'\t' -v v="$(PROJECT_VERSION)" '$$1 == v { print $$4; exit }'); \
+		[ -n "$$app" ] && open -a "$$app" || true; \
+	else \
+		$(UNITY) open; \
+	fi
 
 status: require-unity ## 起動中の Unity エディタの状態を表示
 	$(UNITY) status


### PR DESCRIPTION
Fixes #73

## 原因

`unity open` は既存インスタンスを一切チェックせず、毎回新しい Unity プロセスを起動する（CLI 自体は「Opening project from current directory」と出して exit 0 で終わる）。そのあと Unity 本体が二重起動を拒否してエラーになる。CLI 側の仕様なので Makefile でガードする。

## 変更

`Makefile` の `unity` ターゲットのみ。

- `unity status --format tsv` の Project 列が `$(CURDIR)` と一致するインスタンスを探す
- 見つかれば `unity editors --format tsv` から該当バージョンの .app パスを引いて `open -a` で前面に出すだけ。出力はしない
- 見つからない / `unity status` が失敗した場合は従来どおり `unity open`

worktree でも `$(CURDIR)` が worktree のパスになるので正しく判定できる。複数のエディタが起動している場合、`open -a` はアプリを前面に出すだけでどのプロジェクトのウィンドウが来るかは選べない（コメントに明記）。

## 動作確認

- すでに開いている場合: 出力なしで exit 0、Unity プロセス数は増えない（二重起動しない）
- 開いていない場合の分岐: `make unity UNITY=echo` で `open` 側に入ることを確認
- `make help` の一覧は従来どおり

🤖 Generated with [Claude Code](https://claude.com/claude-code)