### PR TITLE
add: MIDI input device selection page

### DIFF
--- a/Assets/Rector/Scripts/Midi/MidiInputDeviceManager.cs
+++ b/Assets/Rector/Scripts/Midi/MidiInputDeviceManager.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using R3;
+using UnityEngine;
+using RtMidiIn = RtMidi.MidiIn;
+
+namespace Rector.Midi
+{
+    /// <summary>
+    /// 受信対象の MIDI ポートの選択を持つ。AudioInputDeviceManager と同じ流儀。
+    ///
+    /// 一覧は Minis 経由ではなく RtMidi のプローブから取る。Minis の MidiDevice は
+    /// 最初のメッセージを受信するまで生えてこないので、そちらを一覧にすると
+    /// 「挿したのにリストが空」になってしまう。プローブは OpenPort しないので
+    /// 受信そのものには一切関与しない。
+    ///
+    /// NOTE: Minis の MidiDriver は常に全ポートを開くため、選択から外したポートも
+    /// Rector が握ったままになる。ここでできるのはイベントの取捨選択だけ。
+    /// </summary>
+    public sealed class MidiInputDeviceManager : IDisposable
+    {
+        const string PrefsKey = "Rector_MidiInputDevices";
+        const string Separator = "\n";
+
+        readonly HashSet<string> selected = new();
+        readonly ReactiveProperty<string[]> selectedDevices = new(Array.Empty<string>());
+
+        // R3 の既定比較子は EqualityComparer<T>.Default で、配列は Equals を上書きしないので
+        // 参照等価になる。中身を書き換えず必ず新しい配列を代入すること
+        public ReadOnlyReactiveProperty<string[]> SelectedDevices => selectedDevices;
+
+        RtMidiIn probe;
+        bool probeFailed;
+
+        public string[] GetInputDevices()
+        {
+            var p = GetProbe();
+            if (p == null) return Array.Empty<string>();
+
+            try
+            {
+                // PortCount はフィールドではなく毎回 P/Invoke なのでスナップショットする
+                var count = p.PortCount;
+                var names = new string[count];
+                for (var i = 0; i < count; i++)
+                {
+                    names[i] = p.GetPortName(i);
+                }
+
+                return names;
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"Failed to enumerate MIDI input ports: {e.Message}");
+                return Array.Empty<string>();
+            }
+        }
+
+        public bool IsSelected(string portName) => selected.Contains(portName);
+
+        public void Toggle(string portName)
+        {
+            if (string.IsNullOrEmpty(portName)) return;
+
+            var isSelected = !selected.Remove(portName);
+            if (isSelected)
+            {
+                selected.Add(portName);
+            }
+
+            Publish();
+            PlayerPrefs.SetString(PrefsKey, string.Join(Separator, selected));
+            RectorLogger.MidiInputDeviceSelection(portName, isSelected);
+        }
+
+        public void ReloadSelection()
+        {
+            selected.Clear();
+
+            // RemoveEmptyEntries が無いと "" が [""] になり、product が空のデバイスが
+            // 選択済み扱いで通ってしまう
+            var stored = PlayerPrefs.GetString(PrefsKey, "");
+            foreach (var portName in stored.Split(new[] { Separator }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                selected.Add(portName);
+            }
+
+            Publish();
+        }
+
+        void Publish() => selectedDevices.Value = selected.ToArray();
+
+        RtMidiIn GetProbe()
+        {
+            if (probe != null || probeFailed) return probe;
+
+            try
+            {
+                var created = RtMidiIn.Create();
+                // IsOk はハンドルの指す先を読むので、先に IsInvalid (マネージド側の判定) で弾く
+                if (created == null || created.IsInvalid || !created.IsOk)
+                {
+                    created?.Dispose();
+                    probeFailed = true;
+                    return null;
+                }
+
+                probe = created;
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"Failed to create a MIDI probe: {e.Message}");
+                probeFailed = true;
+            }
+
+            return probe;
+        }
+
+        public void Dispose()
+        {
+            probe?.Dispose();
+            probe = null;
+            selectedDevices.Dispose();
+        }
+    }
+}

--- a/Assets/Rector/Scripts/Midi/MidiInputDeviceManager.cs
+++ b/Assets/Rector/Scripts/Midi/MidiInputDeviceManager.cs
@@ -57,8 +57,6 @@ namespace Rector.Midi
             }
         }
 
-        public bool IsSelected(string portName) => selected.Contains(portName);
-
         public void Toggle(string portName)
         {
             if (string.IsNullOrEmpty(portName)) return;

--- a/Assets/Rector/Scripts/Midi/MidiInputDeviceManager.cs.meta
+++ b/Assets/Rector/Scripts/Midi/MidiInputDeviceManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 573ef86da312e45538087a626759ac58

--- a/Assets/Rector/Scripts/Midi/MidiModel.cs
+++ b/Assets/Rector/Scripts/Midi/MidiModel.cs
@@ -12,15 +12,40 @@ namespace Rector.Midi
         readonly Subject<MidiNoteEvent> noteOff = new();
         readonly Subject<MidiCcEvent> controlChange = new();
 
-        // 接続中デバイスの登録簿を兼ねる。値は押しっぱなしのノート番号。
-        readonly Dictionary<MidiDevice, HashSet<int>> heldNotes = new();
+        readonly MidiInputDeviceManager deviceManager;
+        readonly CompositeDisposable disposable = new();
+
+        // 接続中デバイスの登録簿。Minis の MidiDevice は (ポート x チャンネル) ごとに生えるので、
+        // 同じポートのエントリが最大16個並ぶ。
+        readonly Dictionary<MidiDevice, DeviceEntry> devices = new();
+
+        readonly HashSet<string> selectedPorts = new();
+
+        // 未選択ポートからの入力を握りつぶしたことを知らせる。毎イベント出すと洪水になるので1回だけ
+        bool loggedIgnoredInput;
 
         public Observable<MidiNoteEvent> NoteOn => noteOn;
         public Observable<MidiNoteEvent> NoteOff => noteOff;
         public Observable<MidiCcEvent> ControlChange => controlChange;
 
+        public MidiModel(MidiInputDeviceManager deviceManager)
+        {
+            this.deviceManager = deviceManager;
+        }
+
+        sealed class DeviceEntry
+        {
+            // MidiPortName.FromProduct は Substring なので、イベントごとに呼ぶと
+            // スライダーを一本なぞるだけで数百回/秒の文字列確保になる。ここで1回だけ算出する
+            public string PortName;
+            public bool Enabled;
+            public readonly HashSet<int> HeldNotes = new();
+        }
+
         public void Initialize()
         {
+            deviceManager.SelectedDevices.Subscribe(OnSelectionChanged).AddTo(disposable);
+
             InputSystem.onDeviceChange += OnDeviceChange;
 
             // Minis の MidiDevice は最初のメッセージ受信まで生えてこないが、
@@ -31,6 +56,46 @@ namespace Rector.Midi
                 {
                     AddDevice(midiDevice);
                 }
+            }
+        }
+
+        void OnSelectionChanged(string[] portNames)
+        {
+            selectedPorts.Clear();
+            foreach (var portName in portNames)
+            {
+                selectedPorts.Add(portName);
+            }
+
+            // 選択から外れたデバイスの押しっぱなしノートは、ここで解放しないと
+            // Gate 出力が true のまま固着する。emit するとノード側のコードが同期で走るので、
+            // 対象を集めてから流す
+            List<MidiNoteEvent> released = null;
+
+            foreach (var (device, entry) in devices)
+            {
+                var enabled = selectedPorts.Contains(entry.PortName);
+                if (enabled == entry.Enabled) continue;
+
+                if (!enabled && entry.HeldNotes.Count > 0)
+                {
+                    released ??= new List<MidiNoteEvent>();
+                    foreach (var noteNumber in entry.HeldNotes)
+                    {
+                        released.Add(new MidiNoteEvent(device.channel, noteNumber, 0f));
+                    }
+                }
+
+                // 有効化した側も捨てる。無効中の押下は noteOn を emit していないので、
+                // 離したときの note-off も出してはいけない
+                entry.HeldNotes.Clear();
+                entry.Enabled = enabled;
+            }
+
+            if (released == null) return;
+            foreach (var e in released)
+            {
+                noteOff.OnNext(e);
             }
         }
 
@@ -53,24 +118,31 @@ namespace Rector.Midi
 
         void AddDevice(MidiDevice device)
         {
-            if (heldNotes.ContainsKey(device)) return;
+            if (devices.ContainsKey(device)) return;
             device.onWillNoteOn += HandleNoteOn;
             device.onWillNoteOff += HandleNoteOff;
             device.onWillControlChange += HandleControlChange;
-            heldNotes.Add(device, new HashSet<int>());
+
+            var portName = MidiPortName.FromProduct(device.description.product);
+            devices.Add(device, new DeviceEntry
+            {
+                PortName = portName,
+                Enabled = selectedPorts.Contains(portName)
+            });
             RectorLogger.MidiInputDevice(device.description.product, device.channel, connected: true);
         }
 
         void RemoveDevice(MidiDevice device)
         {
-            if (!heldNotes.TryGetValue(device, out var held)) return;
+            if (!devices.TryGetValue(device, out var entry)) return;
             Unsubscribe(device);
-            heldNotes.Remove(device);
+            devices.Remove(device);
             RectorLogger.MidiInputDevice(device.description.product, device.channel, connected: false);
 
             // 切断後は note-off が二度と来ないので、押しっぱなしのノートはここで解放する。
             // これをしないと Gate 出力が true のまま固着する。
-            foreach (var noteNumber in held)
+            if (!entry.Enabled) return;
+            foreach (var noteNumber in entry.HeldNotes)
             {
                 noteOff.OnNext(new MidiNoteEvent(device.channel, noteNumber, 0f));
             }
@@ -83,29 +155,48 @@ namespace Rector.Midi
             device.onWillControlChange -= HandleControlChange;
         }
 
+        // NOTE: HeldNotes の記帳は選択状態に関わらず行い、ゲートするのは OnNext だけ。
+        // 記帳側をゲートすると、無効中に離した鍵が HeldNotes に残り続け、
+        // 再び有効化して無効化するたびに押してもいないノートの note-off が飛ぶ。
         void HandleNoteOn(MidiNoteControl note, float velocity)
         {
-            if (note.device is MidiDevice device && heldNotes.TryGetValue(device, out var held))
-            {
-                held.Add(note.noteNumber);
-            }
+            var entry = GetEntry(note);
+            entry?.HeldNotes.Add(note.noteNumber);
 
+            if (!ShouldEmit(entry)) return;
             noteOn.OnNext(new MidiNoteEvent(GetChannel(note), note.noteNumber, velocity));
         }
 
         void HandleNoteOff(MidiNoteControl note)
         {
-            if (note.device is MidiDevice device && heldNotes.TryGetValue(device, out var held))
-            {
-                held.Remove(note.noteNumber);
-            }
+            var entry = GetEntry(note);
+            entry?.HeldNotes.Remove(note.noteNumber);
 
+            if (!ShouldEmit(entry)) return;
             noteOff.OnNext(new MidiNoteEvent(GetChannel(note), note.noteNumber, 0f));
         }
 
         void HandleControlChange(MidiValueControl control, float value)
         {
+            if (!ShouldEmit(GetEntry(control))) return;
             controlChange.OnNext(new MidiCcEvent(GetChannel(control), control.controlNumber, value));
+        }
+
+        DeviceEntry GetEntry(InputControl control)
+            => control.device is MidiDevice device && devices.TryGetValue(device, out var entry) ? entry : null;
+
+        // 未選択デバイスの取りこぼしを一度だけ知らせる副作用があるので、IsEnabled ではなくこの名前
+        bool ShouldEmit(DeviceEntry entry)
+        {
+            if (entry is { Enabled: true }) return true;
+
+            if (!loggedIgnoredInput)
+            {
+                loggedIgnoredInput = true;
+                RectorLogger.MidiInputIgnored(entry?.PortName ?? "");
+            }
+
+            return false;
         }
 
         static int GetChannel(InputControl control) => (control.device as MidiDevice)?.channel ?? 0;
@@ -113,12 +204,13 @@ namespace Rector.Midi
         public void Dispose()
         {
             InputSystem.onDeviceChange -= OnDeviceChange;
-            foreach (var device in heldNotes.Keys)
+            foreach (var device in devices.Keys)
             {
                 Unsubscribe(device);
             }
 
-            heldNotes.Clear();
+            devices.Clear();
+            disposable.Dispose();
             noteOn.Dispose();
             noteOff.Dispose();
             controlChange.Dispose();

--- a/Assets/Rector/Scripts/Midi/MidiPortName.cs
+++ b/Assets/Rector/Scripts/Midi/MidiPortName.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Rector.Midi
+{
+    /// <summary>
+    /// Minis の MidiDevice 名から MIDI ポート名を取り出す。
+    /// Minis は (ポート x チャンネル) ごとに MidiDevice を生やし、その product を
+    /// "&lt;ポート名&gt; Channel &lt;n&gt;" として組み立てる (Minis.MidiUtility.MakeDeviceDescription)。
+    /// Rector はポート単位で受信可否を決めるので、その規約をここで剥がす。
+    /// </summary>
+    public static class MidiPortName
+    {
+        const string ChannelSuffix = " Channel ";
+
+        public static string FromProduct(string product)
+        {
+            if (string.IsNullOrEmpty(product)) return "";
+
+            // ポート名自体が " Channel " を含みうるので、末尾側の区切りを採用する
+            var index = product.LastIndexOf(ChannelSuffix, StringComparison.Ordinal);
+            return index < 0 ? product : product.Substring(0, index);
+        }
+    }
+}

--- a/Assets/Rector/Scripts/Midi/MidiPortName.cs.meta
+++ b/Assets/Rector/Scripts/Midi/MidiPortName.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 65183bdef69304e139050025ceb81a3c

--- a/Assets/Rector/Scripts/Rector.asmdef
+++ b/Assets/Rector/Scripts/Rector.asmdef
@@ -11,6 +11,7 @@
         "R3.Unity",
         "Lasp.Runtime",
         "Minis",
+        "RtMidi.Runtime",
         "Unity.Pipeline"
     ],
     "includePlatforms": [],

--- a/Assets/Rector/Scripts/RectorInstaller.cs
+++ b/Assets/Rector/Scripts/RectorInstaller.cs
@@ -50,7 +50,8 @@ namespace Rector
             Register(new ThresholdAdjuster(mixerModel));
 
             // midi
-            var midiModel = Register(new MidiModel());
+            var midiInputDeviceManager = Register(new MidiInputDeviceManager());
+            var midiModel = Register(new MidiModel(midiInputDeviceManager));
 
             // vfx
             var vfxManager = Register(new VfxManager(rectorSettingsAsset.vfxSettings));
@@ -72,6 +73,7 @@ namespace Rector
             var bgSceneManager = Register(new BGSceneManager(loadingView, rectorSettingsAsset.sceneSettings, nodeTemplateRepository, nodeBehaviourProxyRepository, graphPage));
             var scenePage = Register(new ScenePageModel(hudView.ScenePageView, bgSceneManager));
             var audioInputDevicePage = Register(new AudioInputDevicePageModel(audioInputDeviceManager, hudView.AudioInputDevicePageView));
+            var midiInputDevicePage = Register(new MidiInputDevicePageModel(midiInputDeviceManager, hudView.MidiInputDevicePageView));
             var displaySettingsPage = Register(new DisplaySettingsPageModel(hudView.DisplaySettingsPageView));
             var graphSettingsPage = Register(new GraphSettingsPageModel(hudView.GraphSettingsPageView, graphPage.Groups, graphPage.GuideSettings));
             var copyrightNoticesPage = Register(new CopyrightNoticesPageModel(hudView.CopyrightNoticesPageView));
@@ -79,6 +81,7 @@ namespace Rector
 
             var menuPage = Register(new SystemPageModel(
                 audioInputDevicePage,
+                midiInputDevicePage,
                 displaySettingsPage,
                 graphSettingsPage,
                 copyrightNoticesPage,
@@ -124,6 +127,7 @@ namespace Rector
 
             // reload last device
             audioInputDeviceManager.ReloadLastDevice();
+            midiInputDeviceManager.ReloadSelection();
 
             // set first camera active
             cameraManager.GetCameraBehaviours()[0].IsActive.Value = true;

--- a/Assets/Rector/Scripts/RectorLogger.cs
+++ b/Assets/Rector/Scripts/RectorLogger.cs
@@ -43,6 +43,16 @@ namespace Rector
             LogInternal($"[SYSTEM/MIDI] {(connected ? "connected" : "disconnected")} device='{product}' ch={channel + 1}");
         }
 
+        public static void MidiInputDeviceSelection(string portName, bool selected)
+        {
+            LogInternal($"[SYSTEM/MIDI] {(selected ? "selected" : "deselected")} device='{portName}'");
+        }
+
+        public static void MidiInputIgnored(string portName)
+        {
+            LogInternal($"[SYSTEM/MIDI] ignored input from '{portName}'. Enable it in System > MIDI Settings.");
+        }
+
         public static void MidiLearn(Node node, string status)
         {
             LogInternal($"[NODE/MIDI-LEARN] id={node.Id} name='{node.Name}' {status}");

--- a/Assets/Rector/Scripts/UI/Hud/HudView.cs
+++ b/Assets/Rector/Scripts/UI/Hud/HudView.cs
@@ -26,6 +26,7 @@ namespace Rector.UI.Hud
         public ButtonListPageView ScenePageView { get; }
         public ButtonListPageView SystemPageView { get; }
         public ButtonListPageView AudioInputDevicePageView { get; }
+        public ButtonListPageView MidiInputDevicePageView { get; }
         public ButtonListPageView DisplaySettingsPageView { get; }
         public ButtonListPageView GraphSettingsPageView { get; }
         public CopyrightNoticesPageView CopyrightNoticesPageView { get; }
@@ -51,6 +52,7 @@ namespace Rector.UI.Hud
             ScenePageView = new ButtonListPageView(root.Q<VisualElement>("scene-page"), uiInputAction);
             SystemPageView = new ButtonListPageView(root.Q<VisualElement>("system-page"), uiInputAction);
             AudioInputDevicePageView = new ButtonListPageView(root.Q<VisualElement>("audio-input-device-page"), uiInputAction);
+            MidiInputDevicePageView = new ButtonListPageView(root.Q<VisualElement>("midi-input-device-page"), uiInputAction);
             DisplaySettingsPageView = new ButtonListPageView(root.Q<VisualElement>("display-settings-page"), uiInputAction);
             GraphSettingsPageView = new ButtonListPageView(root.Q<VisualElement>("graph-settings-page"), uiInputAction);
             CopyrightNoticesPageView = new CopyrightNoticesPageView(root.Q<VisualElement>("copyright-notices-page"), uiInputAction);

--- a/Assets/Rector/Scripts/UI/Hud/MidiInputDevicePageModel.cs
+++ b/Assets/Rector/Scripts/UI/Hud/MidiInputDevicePageModel.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using R3;
+using Rector.Midi;
+
+namespace Rector.UI.Hud
+{
+    public sealed class MidiInputDevicePageModel : IInitializable, IDisposable, IButtonListPageModel
+    {
+        readonly ReactiveProperty<bool> isVisible = new(false);
+        readonly MidiInputDeviceManager midiInputDeviceManager;
+        readonly ButtonListPageView view;
+        readonly List<RectorButtonState> buttons = new();
+        readonly SerialDisposable enterDisposable = new();
+        readonly CompositeDisposable disposable = new();
+        Action onExit;
+
+        ReadOnlyReactiveProperty<bool> IButtonListPageModel.IsVisible => isVisible;
+        IEnumerable<RectorButtonState> IButtonListPageModel.GetButtons() => buttons;
+
+        int index;
+
+        public MidiInputDevicePageModel(MidiInputDeviceManager midiInputDeviceManager,
+            ButtonListPageView view)
+        {
+            this.midiInputDeviceManager = midiInputDeviceManager;
+            this.view = view;
+        }
+
+        public void Enter(Action onExitAction)
+        {
+            RefreshDevices();
+
+            index = 0;
+            if (buttons.Count > 0)
+            {
+                buttons[index].IsFocused.Value = true;
+            }
+
+            onExit = onExitAction;
+            isVisible.Value = true;
+        }
+
+        void IInitializable.Initialize()
+        {
+            view.Bind(this).AddTo(disposable);
+        }
+
+        void RefreshDevices()
+        {
+            buttons.Clear();
+            var d = new CompositeDisposable();
+            foreach (var portName in midiInputDeviceManager.GetInputDevices().OrderBy(x => x))
+            {
+                var button = new RectorButtonState(portName, () => midiInputDeviceManager.Toggle(portName));
+                buttons.Add(button);
+
+                // トグルしてもリストは組み直さないので、ハイライトだけが反応してフォーカスは動かない
+                midiInputDeviceManager.SelectedDevices
+                    .Subscribe(selected => button.IsHighlighted.Value = Array.IndexOf(selected, portName) >= 0)
+                    .AddTo(d);
+            }
+
+            // MIDI 機器を挿していないのは日常的に起きる。真っ白なページだと壊れたのと区別が付かない
+            if (buttons.Count == 0)
+            {
+                buttons.Add(new RectorButtonState("No MIDI Devices", () => { }));
+            }
+
+            enterDisposable.Disposable = d;
+        }
+
+        void IButtonListPageModel.Submit()
+        {
+            if (buttons.Count == 0) return;
+            buttons[index].OnClick();
+        }
+
+        void IButtonListPageModel.Cancel()
+        {
+            enterDisposable.Disposable = null;
+            isVisible.Value = false;
+            onExit?.Invoke();
+        }
+
+        void IButtonListPageModel.Navigate(bool next)
+        {
+            if (buttons.Count == 0) return;
+            buttons[index].IsFocused.Value = false;
+
+            index += next ? 1 : -1;
+            index = (index + buttons.Count) % buttons.Count;
+
+            buttons[index].IsFocused.Value = true;
+        }
+
+        void IDisposable.Dispose()
+        {
+            enterDisposable.Dispose();
+            disposable.Dispose();
+        }
+    }
+}

--- a/Assets/Rector/Scripts/UI/Hud/MidiInputDevicePageModel.cs.meta
+++ b/Assets/Rector/Scripts/UI/Hud/MidiInputDevicePageModel.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 567654cfce4204549aabdc0bca8e13b1

--- a/Assets/Rector/Scripts/UI/Hud/SystemPageModel.cs
+++ b/Assets/Rector/Scripts/UI/Hud/SystemPageModel.cs
@@ -11,6 +11,7 @@ namespace Rector.UI.Hud
         int index;
 
         readonly AudioInputDevicePageModel audioInputDevicePageModel;
+        readonly MidiInputDevicePageModel midiInputDevicePageModel;
         readonly DisplaySettingsPageModel displaySettingsPageModel;
         readonly GraphSettingsPageModel graphSettingsPageModel;
         readonly CopyrightNoticesPageModel copyrightNoticesPageModel;
@@ -20,6 +21,7 @@ namespace Rector.UI.Hud
 
         public SystemPageModel(
             AudioInputDevicePageModel audioInputDevicePageModel,
+            MidiInputDevicePageModel midiInputDevicePageModel,
             DisplaySettingsPageModel displaySettingsPageModel,
             GraphSettingsPageModel graphSettingsPageModel,
             CopyrightNoticesPageModel copyrightNoticesPageModel,
@@ -27,6 +29,7 @@ namespace Rector.UI.Hud
         )
         {
             this.audioInputDevicePageModel = audioInputDevicePageModel;
+            this.midiInputDevicePageModel = midiInputDevicePageModel;
             this.displaySettingsPageModel = displaySettingsPageModel;
             this.graphSettingsPageModel = graphSettingsPageModel;
             this.copyrightNoticesPageModel = copyrightNoticesPageModel;
@@ -34,6 +37,7 @@ namespace Rector.UI.Hud
             buttons = new RectorButtonState[]
             {
                 new("Audio Settings", ShowAudioSettings),
+                new("MIDI Settings", ShowMidiSettings),
                 new("Display Settings", ShowDisplaySettings),
                 new("Graph Settings", ShowGraphSettings),
                 new("Copyright Notices", ShowCopyrightNotices),
@@ -89,6 +93,12 @@ namespace Rector.UI.Hud
         {
             isVisible.Value = false;
             audioInputDevicePageModel.Enter(Resume);
+        }
+
+        void ShowMidiSettings()
+        {
+            isVisible.Value = false;
+            midiInputDevicePageModel.Enter(Resume);
         }
 
         void ShowDisplaySettings()

--- a/Assets/Rector/StaticResources/UI/Hud.uxml
+++ b/Assets/Rector/StaticResources/UI/Hud.uxml
@@ -36,6 +36,9 @@
             <engine:VisualElement name="audio-input-device-page" class="rector-page">
                 <engine:VisualElement name="left-list" class="rector-button-list" />
             </engine:VisualElement>
+            <engine:VisualElement name="midi-input-device-page" class="rector-page">
+                <engine:VisualElement name="left-list" class="rector-button-list" />
+            </engine:VisualElement>
             <engine:VisualElement name="display-settings-page" class="rector-page">
                 <engine:VisualElement name="left-list" class="rector-button-list" />
             </engine:VisualElement>

--- a/Assets/Rector/Tests/EditMode/MidiPortNameTests.cs
+++ b/Assets/Rector/Tests/EditMode/MidiPortNameTests.cs
@@ -1,0 +1,42 @@
+using NUnit.Framework;
+using Rector.Midi;
+
+namespace Rector.Tests.EditMode
+{
+    /// <summary>
+    /// MidiPortName.FromProduct のテスト。
+    /// 入力は Minis.MidiUtility.MakeDeviceDescription が組み立てる product 文字列
+    /// ("&lt;ポート名&gt; Channel &lt;n&gt;")。
+    /// </summary>
+    public sealed class MidiPortNameTests
+    {
+        [Test]
+        public void FromProduct_StripsChannelSuffix()
+        {
+            Assert.AreEqual("nanoKONTROL2 SLIDER/KNOB",
+                MidiPortName.FromProduct("nanoKONTROL2 SLIDER/KNOB Channel 0"));
+            Assert.AreEqual("Launchkey Mini MK3 MIDI",
+                MidiPortName.FromProduct("Launchkey Mini MK3 MIDI Channel 15"));
+        }
+
+        [Test]
+        public void FromProduct_UsesTheLastSeparator()
+        {
+            // ポート名自体が " Channel " を含むケース
+            Assert.AreEqual("My Channel Strip", MidiPortName.FromProduct("My Channel Strip Channel 3"));
+        }
+
+        [Test]
+        public void FromProduct_ReturnsInputWhenSuffixIsAbsent()
+        {
+            Assert.AreEqual("NoSuffix", MidiPortName.FromProduct("NoSuffix"));
+        }
+
+        [Test]
+        public void FromProduct_ReturnsEmptyForNullOrEmpty()
+        {
+            Assert.AreEqual("", MidiPortName.FromProduct(null));
+            Assert.AreEqual("", MidiPortName.FromProduct(""));
+        }
+    }
+}

--- a/Assets/Rector/Tests/EditMode/MidiPortNameTests.cs.meta
+++ b/Assets/Rector/Tests/EditMode/MidiPortNameTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f00a9fb79c50949788542d59006cedea

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -14,6 +14,7 @@
     "jp.hadashikick.vyaml": "https://github.com/hadashiA/VYaml.git?path=VYaml.Unity/Assets/VYaml#1.4.0",
     "jp.keijiro.lasp": "https://github.com/keijiro/Lasp.git?path=Packages/jp.keijiro.lasp#2.1.8",
     "jp.keijiro.minis": "1.3.2",
+    "jp.keijiro.rtmidi": "2.2.0",
     "com.unity.modules.accessibility": "1.0.0",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -266,7 +266,7 @@
     },
     "jp.keijiro.rtmidi": {
       "version": "2.2.0",
-      "depth": 1,
+      "depth": 0,
       "source": "registry",
       "dependencies": {},
       "url": "https://registry.npmjs.com"


### PR DESCRIPTION
Closes #61

## Why

Rector received input from every connected MIDI port and channel, so a setup with more than one controller picked up unintended input. MIDI Learn had the same problem: it grabbed the next message from any device.

## What

A MIDI Settings page modelled on Audio Settings, sitting right after it in the System page.

```
MIDI Settings
──────────────────────────────
▸ nanoKONTROL2 SLIDER/KNOB     ← highlighted = receiving
  Steinberg UR22C Port1
```

- **Selection is per port**, and multiple ports can be on at once. Submit on a row toggles it. All 16 channels of a selected port pass through.
- **Persisted** to `Rector_MidiInputDevices` (newline-separated port names). Selections for ports that are not currently connected are kept, so unplugging and replugging keeps the setting.
- `MidiModel` **filters at emission time**, so a change takes effect immediately and **MIDI Learn follows the selection** with no change to `MidiSourceNode`.
- `ButtonListPageView` / `RectorButton` / USS are untouched — ON uses the existing `rector-button--highlighted`.

### Why the device list comes from RtMidi, not InputSystem

Minis only materialises a `MidiDevice` once that (port, channel) has sent its first message. An InputSystem-based list is therefore empty until you touch a knob. Verified on this machine — two ports are physically connected while `InputSystem.devices` holds no `MidiDevice` at all:

```
RtMidi probe        → count=2 names=[Steinberg UR22C Port1 | nanoKONTROL2 SLIDER/KNOB]
InputSystem.devices → (no MidiDevice yet)
```

The probe never calls `OpenPort`, and reports exactly the names Minis uses internally (both come from `probe.GetPortName(i)`). `jp.keijiro.rtmidi` moves from a transitive dependency of Minis to a declared one.

## Behaviour changes worth knowing

**With nothing selected, no MIDI input is accepted.** This differs from the spike in #44, where everything was accepted. The first dropped message logs a line pointing at the settings page so the silence is explainable.

**Deselecting a port does not release it.** `MidiDriver.OpenAllAvailablePorts` opens every port and Minis offers no way to stop it, so this PR can only drop events. Harmless on macOS CoreMIDI, which shares sources; on Windows WinMM `midiInOpen` is exclusive, so Rector still blocks other apps from those ports. Fixing it properly means a change in Minis itself — worth a follow-up issue.

## Held notes

Deselecting a port while a key is held would leave `Gate` stuck true, so held notes are released on that transition, the same way `RemoveDevice` handles a disconnect. Note bookkeeping stays unconditional and only the emit is gated — gating the bookkeeping instead would strand notes released while a port was off and replay them as phantom note-offs later.

## Out of scope

- Per-channel filtering. The filter keys on port name, so it can be widened to `(port, channel)` later.
- Pre-registering devices into the node creation UI (the idea in #61 / #44).

## Testing

- batchmode compile: 0 errors
- EditMode tests: 14/14, including 4 new cases for `MidiPortName.FromProduct`
- `dotnet format` on both csproj: no changes
- RtMidi probe verified against real hardware (output above)

Manual pass with hardware still to do: toggling filters the right device, MIDI Learn ignores deselected ports, and no stuck `Gate` when deselecting mid-note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013kXD81Anyt3CiowRXqc6mm