### PR TITLE
fix: show the MIDI node value as a bottom gauge so focus stays visible

### DIFF
--- a/Assets/Rector/Scripts/UI/Graphs/Nodes/MidiNodeView.cs
+++ b/Assets/Rector/Scripts/UI/Graphs/Nodes/MidiNodeView.cs
@@ -10,14 +10,15 @@ namespace Rector.UI.Graphs.Nodes
         {
             midiNode.DisplayLabel.Subscribe(text => NameLabel.text = text).AddTo(Disposables);
 
-            // ノード背景を値のスライダーとして使う。最初の子として挿すことで icon/label の下に描く
-            var fill = new VisualElement();
-            fill.AddToClassList("rector-node-value-fill");
+            // 値は content 下端のゲージで示す。ラベルが黒0.2の背景を持つので、
+            // 濃さを一定にするため最後の子として最前面に置く(バーは文字に被らない)
+            var gauge = new VisualElement { pickingMode = PickingMode.Ignore };
+            gauge.AddToClassList("rector-node-value-gauge");
             var content = Root.Q<VisualElement>("content");
-            content.Insert(0, fill);
+            content.Add(gauge);
 
             midiNode.DisplayValue
-                .Subscribe(value => fill.style.width = Length.Percent(Mathf.Clamp01(value) * 100f))
+                .Subscribe(value => gauge.style.width = Length.Percent(Mathf.Clamp01(value) * 100f))
                 .AddTo(Disposables);
         }
     }

--- a/Assets/Rector/StaticResources/UI/StyleSheets/RectorNode.uss
+++ b/Assets/Rector/StaticResources/UI/StyleSheets/RectorNode.uss
@@ -92,13 +92,14 @@
     display: flex;
 }
 
-.rector-node-value-fill {
+/* MIDIノードの値ゲージ。面で塗るとフォーカス中の黒背景を覆ってしまうので、下端のバーで示す */
+.rector-node-value-gauge {
     position: absolute;
     left: 0;
-    top: 0;
     bottom: 0;
+    height: 2px;
     width: 0;
-    background-color: rgba(255, 255, 255, 0.2);
+    background-color: rgba(255, 255, 255, 0.5);
 }
 
 .rector-node-mute {


### PR DESCRIPTION
Fixes #70

## 原因

フォーカス中のノードは `content` の背景を黒（不透明）にすることで示している。`.rector-node--selected` の枠は `--rector-border-color` = 白0.1 でほぼ見えないので、実質この黒背景が唯一の手がかりになっている。

`MidiNodeView` は同じ `content` の中に全面フィル（白0.2、width = 値%）を敷いてゲージにしていたため、**値が1になるとフィルが黒背景を丸ごと覆い、フォーカス中かどうかが判別できなくなっていた**。

## 変更

ゲージを面から `content` 下端のバーに変える。背景を覆わなくなるので、既存のフォーカス表現がそのまま生きる。フォーカス/ターゲット/ミュートのスタイルは無変更なので、MIDI以外のノードの見た目は変わらない。

- `RectorNode.uss`: `.rector-node-value-fill`（全面・白0.2）を `.rector-node-value-gauge`（下端2px・白0.5）に作り替え。2px/白0.5 は `.rector-node-slot--active` と同じ寸法・濃度
- `MidiNodeView.cs`: クラス名の変更と、`content.Insert(0, ...)` → `content.Add(...)`。`name-label` が `.rector-label` の黒0.2 背景を content 全体に伸ばして持つため、最背面だとラベル領域とアイコン領域でゲージの濃さが変わる。下端バーは文字に被らないので最前面に置いて濃度を揃えた。装飾要素なので `pickingMode = Ignore` も付与

値の購読ロジック（`DisplayValue` → `Length.Percent`）は変更なし。

## 動作確認

worktree 専用エディタ（port 7801）で確認。

- recompile: `completed` / `failed: false`、console error 0件
- `dotnet format` 済み
- プレイモードで MIDI CC / MIDI Note ノードを作り、`eval` でビジュアルツリーを実測:
  - ゲージ: 高さ 1.5（2px × パネルスケール）、背景 `RGBA(1, 1, 1, 0.5)`、`content` の最後の子
  - 幅を100%（値1相当）にしても、選択中ノードの `content` は `RGBA(0, 0, 0, 1.0)` のまま = 黒背景が生きている
  - 非選択ノードは `RGBA(0, 0, 0, 0.2)` で、両者の差が出ることを確認

HUD は UI Toolkit のオーバーレイパネルなので `capture_game_view` / `screenshot` には写らず、スクリーンショットでの確認はできていない。実際の見え方はエディタ上で目視確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

