### PR TITLE
change: make settings pages one row per setting

### DIFF
--- a/Assets/Rector/Scripts/Midi/MidiInputDeviceManager.cs
+++ b/Assets/Rector/Scripts/Midi/MidiInputDeviceManager.cs
@@ -61,11 +61,15 @@ namespace Rector.Midi
         {
             if (string.IsNullOrEmpty(portName)) return;
 
-            var isSelected = !selected.Remove(portName);
-            if (isSelected)
-            {
-                selected.Add(portName);
-            }
+            SetSelected(portName, !selected.Contains(portName));
+        }
+
+        public void SetSelected(string portName, bool isSelected)
+        {
+            if (string.IsNullOrEmpty(portName)) return;
+
+            var changed = isSelected ? selected.Add(portName) : selected.Remove(portName);
+            if (!changed) return;
 
             Publish();
             PlayerPrefs.SetString(PrefsKey, string.Join(Separator, selected));

--- a/Assets/Rector/Scripts/UI/Hud/AudioInputDevicePageModel.cs
+++ b/Assets/Rector/Scripts/UI/Hud/AudioInputDevicePageModel.cs
@@ -3,40 +3,42 @@ using System.Collections.Generic;
 using System.Linq;
 using R3;
 using Rector.Audio;
+using Rector.UI.Settings;
 
 namespace Rector.UI.Hud
 {
-    public sealed class AudioInputDevicePageModel : IInitializable, IDisposable, IButtonListPageModel
+    public sealed class AudioInputDevicePageModel : IInitializable, IDisposable, ISettingsPageModel
     {
         readonly ReactiveProperty<bool> isVisible = new(false);
         readonly AudioInputDeviceManager audioInputDeviceManager;
-        readonly ButtonListPageView view;
-        readonly List<RectorButtonState> buttons = new();
-        readonly SerialDisposable enterDisposable = new();
+        readonly SettingsPageView view;
+
+        // 1つだけ選ぶ設定なので、送るたびに入力が切り替わらないメニュー行にする
+        readonly SelectorRowState deviceRow;
+        readonly ISettingRow[] rows;
+
+        /// <summary>行の候補と対で持つ。確定したインデックスから実体を引く。</summary>
+        readonly List<AudioInputDeviceInfo> devices = new();
+
         readonly CompositeDisposable disposable = new();
         Action onExit;
 
-        ReadOnlyReactiveProperty<bool> IButtonListPageModel.IsVisible => isVisible;
-        IEnumerable<RectorButtonState> IButtonListPageModel.GetButtons() => buttons;
-
-        int index;
+        ReadOnlyReactiveProperty<bool> ISettingsPageModel.IsVisible => isVisible;
+        IReadOnlyList<ISettingRow> ISettingsPageModel.GetRows() => rows;
 
         public AudioInputDevicePageModel(AudioInputDeviceManager audioInputDeviceManager,
-            ButtonListPageView view)
+            SettingsPageView view)
         {
             this.audioInputDeviceManager = audioInputDeviceManager;
             this.view = view;
+
+            deviceRow = new SelectorRowState("Input Device", Select);
+            rows = new ISettingRow[] { deviceRow };
         }
 
         public void Enter(Action onExitAction)
         {
             RefreshDevices();
-
-            index = 0;
-            if (buttons.Count > 0)
-            {
-                buttons[index].IsFocused.Value = true;
-            }
 
             onExit = onExitAction;
             isVisible.Value = true;
@@ -49,49 +51,36 @@ namespace Rector.UI.Hud
 
         void RefreshDevices()
         {
-            buttons.Clear();
-            var d = new CompositeDisposable();
-            foreach (var inputDevice in audioInputDeviceManager.GetInputDevices().OrderBy(x => x.Name))
+            devices.Clear();
+            devices.AddRange(audioInputDeviceManager.GetInputDevices().OrderBy(x => x.Name));
+
+            // 入力デバイスが無いのは起こり得る。空のページだと壊れたのと区別が付かない
+            if (devices.Count == 0)
             {
-                var button = new RectorButtonState(inputDevice.Name, () => audioInputDeviceManager.SwitchDevice(inputDevice));
-                buttons.Add(button);
-                audioInputDeviceManager.CurrentInputDevice
-                    .Where(x => x.IsValid)
-                    .Subscribe(currentDevice => button.IsHighlighted.Value = currentDevice.Equals(inputDevice))
-                    .AddTo(d);
+                deviceRow.SetOptions(new[] { "None" }, 0);
+                return;
             }
 
-            enterDisposable.Disposable = d;
+            var current = audioInputDeviceManager.CurrentInputDevice.CurrentValue;
+            deviceRow.SetOptions(
+                devices.Select(x => x.Name).ToArray(),
+                current.IsValid ? devices.IndexOf(current) : -1);
         }
 
-        void IButtonListPageModel.Submit()
+        void Select(int index)
         {
-            if (buttons.Count == 0) return;
-            buttons[index].OnClick();
+            if (index < 0 || index >= devices.Count) return;
+
+            audioInputDeviceManager.SwitchDevice(devices[index]);
         }
 
-        void IButtonListPageModel.Cancel()
+        void ISettingsPageModel.Cancel()
         {
-            enterDisposable.Disposable = null;
             isVisible.Value = false;
             onExit?.Invoke();
+            onExit = null;
         }
 
-        void IButtonListPageModel.Navigate(bool next)
-        {
-            if (buttons.Count == 0) return;
-            buttons[index].IsFocused.Value = false;
-
-            index += next ? 1 : -1;
-            index = (index + buttons.Count) % buttons.Count;
-
-            buttons[index].IsFocused.Value = true;
-        }
-
-        void IDisposable.Dispose()
-        {
-            enterDisposable.Dispose();
-            disposable.Dispose();
-        }
+        void IDisposable.Dispose() => disposable.Dispose();
     }
 }

--- a/Assets/Rector/Scripts/UI/Hud/DisplaySettingsPageModel.cs
+++ b/Assets/Rector/Scripts/UI/Hud/DisplaySettingsPageModel.cs
@@ -1,84 +1,99 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using R3;
+using Rector.UI.Settings;
 using UnityEngine;
 
 namespace Rector.UI.Hud
 {
-    public sealed class DisplaySettingsPageModel : IInitializable, IDisposable, IButtonListPageModel
+    public sealed class DisplaySettingsPageModel : IInitializable, IDisposable, ISettingsPageModel
     {
-        readonly ButtonListPageView view;
+        static readonly FullScreenMode[] FullScreenModes =
+        {
+            FullScreenMode.ExclusiveFullScreen,
+            FullScreenMode.FullScreenWindow,
+            FullScreenMode.MaximizedWindow,
+            FullScreenMode.Windowed,
+        };
+
+        readonly SettingsPageView view;
         readonly ReactiveProperty<bool> isVisible = new(false);
-        ReadOnlyReactiveProperty<bool> IButtonListPageModel.IsVisible => isVisible;
+        ReadOnlyReactiveProperty<bool> ISettingsPageModel.IsVisible => isVisible;
+
+        // どちらも送るたびにウィンドウが跳ねるので、メニューを閉じるまで適用しない行にする
+        readonly SelectorRowState fullScreenRow;
+        readonly SelectorRowState resolutionRow;
+        readonly ISettingRow[] rows;
+
+        /// <summary>解像度行の候補。表示文字列と対で、確定したインデックスから引く。</summary>
+        readonly List<Vector2Int> resolutions = new();
 
         Action onExit;
-
-        int index;
-
-        readonly List<RectorButtonState> buttons = new();
-
         IDisposable disposable;
 
-        public DisplaySettingsPageModel(ButtonListPageView view)
+        public DisplaySettingsPageModel(SettingsPageView view)
         {
             this.view = view;
+
+            fullScreenRow = new SelectorRowState("Screen Mode", i => ChangeFullScreenMode(FullScreenModes[i]));
+            resolutionRow = new SelectorRowState("Resolution", i => UpdateResolution(resolutions[i]));
+            rows = new ISettingRow[] { fullScreenRow, resolutionRow };
         }
 
-        public void Initialize()
-        {
-            disposable = view.Bind(this);
-        }
+        public void Initialize() => disposable = view.Bind(this);
 
         public void Dispose() => disposable?.Dispose();
 
         public void Enter(Action onExitAction)
         {
-            index = 0;
             onExit = onExitAction;
 
-            buttons.Clear();
-            buttons.Add(new RectorButtonState(FullScreenMode.ExclusiveFullScreen.ToString(), () => ChangeFullScreenMode(FullScreenMode.ExclusiveFullScreen)));
-            buttons.Add(new RectorButtonState(FullScreenMode.FullScreenWindow.ToString(), () => ChangeFullScreenMode(FullScreenMode.FullScreenWindow)));
-            buttons.Add(new RectorButtonState(FullScreenMode.MaximizedWindow.ToString(), () => ChangeFullScreenMode(FullScreenMode.MaximizedWindow)));
-            buttons.Add(new RectorButtonState(FullScreenMode.Windowed.ToString(), () => ChangeFullScreenMode(FullScreenMode.Windowed)));
-
-            var resolutions = Screen.resolutions;
-            foreach (var resolution in resolutions)
-            {
-                buttons.Add(new RectorButtonState($"{resolution.width} x {resolution.height}", () => UpdateResolution(resolution)));
-            }
-
-            if (buttons.Count > 0)
-            {
-                buttons[0].IsFocused.Value = true;
-            }
+            // 現在値は毎回Screenから読み直す。ここ以外から変わっていても表示が嘘にならない。
+            fullScreenRow.SetOptions(
+                FullScreenModes.Select(x => x.ToString()).ToArray(),
+                Array.IndexOf(FullScreenModes, Screen.fullScreenMode));
+            RefreshResolutions();
 
             isVisible.Value = true;
         }
 
-        void IButtonListPageModel.Submit()
+        /// <summary>
+        /// 環境の解像度を読み直す。Screen.resolutionsはリフレッシュレート違いを別々に返すが、
+        /// 適用時のリフレッシュレートは60固定なので、幅と高さで重複を潰して1行にする。
+        /// </summary>
+        void RefreshResolutions()
         {
-            buttons[index].OnClick();
+            resolutions.Clear();
+            resolutions.AddRange(Screen.resolutions
+                .Select(x => new Vector2Int(x.width, x.height))
+                .Distinct()
+                .OrderBy(x => x.x)
+                .ThenBy(x => x.y));
+
+            // ウィンドウモードでは今のサイズが候補に無いことがある。
+            // 無いまま別の候補を現在値として見せると嘘になるので、先頭に足して選ばせる。
+            var current = new Vector2Int(Screen.width, Screen.height);
+            var index = resolutions.IndexOf(current);
+            if (index < 0)
+            {
+                resolutions.Insert(0, current);
+                index = 0;
+            }
+
+            resolutionRow.SetOptions(resolutions.Select(ToLabel).ToArray(), index);
         }
 
-        void IButtonListPageModel.Cancel()
+        IReadOnlyList<ISettingRow> ISettingsPageModel.GetRows() => rows;
+
+        void ISettingsPageModel.Cancel()
         {
             isVisible.Value = false;
             onExit?.Invoke();
             onExit = null;
         }
 
-        void IButtonListPageModel.Navigate(bool next)
-        {
-            buttons[index].IsFocused.Value = false;
-
-            index += next ? 1 : -1;
-            index = (index + buttons.Count) % buttons.Count;
-
-            buttons[index].IsFocused.Value = true;
-        }
-
-        IEnumerable<RectorButtonState> IButtonListPageModel.GetButtons() => buttons;
+        static string ToLabel(Vector2Int resolution) => $"{resolution.x} x {resolution.y}";
 
         static void ChangeFullScreenMode(FullScreenMode fullScreenMode)
         {
@@ -90,14 +105,14 @@ namespace Rector.UI.Hud
             RectorLogger.Resolution(Screen.width, Screen.height, fullScreenMode);
         }
 
-        void UpdateResolution(Resolution resolution)
+        static void UpdateResolution(Vector2Int resolution)
         {
-            Screen.SetResolution(resolution.width, resolution.height, Screen.fullScreenMode, new RefreshRate
+            Screen.SetResolution(resolution.x, resolution.y, Screen.fullScreenMode, new RefreshRate
             {
                 numerator = 60,
                 denominator = 1
             });
-            RectorLogger.Resolution(resolution.width, resolution.height, Screen.fullScreenMode);
+            RectorLogger.Resolution(resolution.x, resolution.y, Screen.fullScreenMode);
         }
     }
 }

--- a/Assets/Rector/Scripts/UI/Hud/GraphSettingsPageModel.cs
+++ b/Assets/Rector/Scripts/UI/Hud/GraphSettingsPageModel.cs
@@ -1,60 +1,56 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using R3;
 using Rector.UI.GraphPages;
 using Rector.UI.LayeredGraphDrawing;
+using Rector.UI.Settings;
 
 namespace Rector.UI.Hud
 {
-    public sealed class GraphSettingsPageModel : IInitializable, IDisposable, IButtonListPageModel
+    public sealed class GraphSettingsPageModel : IInitializable, IDisposable, ISettingsPageModel
     {
-        readonly ButtonListPageView view;
+        static readonly InputGuideMode[] GuideModes = { InputGuideMode.Off, InputGuideMode.DualShock, InputGuideMode.Xbox };
+        static readonly string[] GuideOptions = GuideModes.Select(x => x.ToString()).ToArray();
+
+        static readonly string[] GroupCountOptions = Enumerable
+            .Range(NodeGroups.MinCount, NodeGroups.MaxCount - NodeGroups.MinCount + 1)
+            .Select(x => x.ToString())
+            .ToArray();
+
+        readonly SettingsPageView view;
         readonly NodeGroups groups;
         readonly InputGuideSettings guideSettings;
         readonly ReactiveProperty<bool> isVisible = new(false);
-        ReadOnlyReactiveProperty<bool> IButtonListPageModel.IsVisible => isVisible;
+        ReadOnlyReactiveProperty<bool> ISettingsPageModel.IsVisible => isVisible;
 
-        readonly List<RectorButtonState> buttons = new();
-        readonly List<(InputGuideMode Mode, RectorButtonState Button)> guideButtons = new();
-
-        const int GroupButtonCount = NodeGroups.MaxCount - NodeGroups.MinCount + 1;
+        // グループ数は送るたびにグラフが組み変わるのが見えるのでステッパー、
+        // ガイド表記は候補を並べて選ぶ方が分かりやすいのでメニューにする
+        readonly StepperRowState groupCountRow;
+        readonly SelectorRowState guideRow;
+        readonly ISettingRow[] rows;
 
         Action onExit;
-        int index;
         IDisposable disposable;
 
-        public GraphSettingsPageModel(ButtonListPageView view, NodeGroups groups, InputGuideSettings guideSettings)
+        public GraphSettingsPageModel(SettingsPageView view, NodeGroups groups, InputGuideSettings guideSettings)
         {
             this.view = view;
             this.groups = groups;
             this.guideSettings = guideSettings;
 
-            // ボタン順序: [Groups 1..8][Guide: Off][Guide: DualShock][Guide: Xbox]。
-            // Enter()のカーソルシードとUpdateGroupHighlightはGroupsが先頭に並ぶ前提。
-            for (var count = NodeGroups.MinCount; count <= NodeGroups.MaxCount; count++)
-            {
-                var value = count;
-                buttons.Add(new RectorButtonState($"Groups: {value}", () => groups.SetCount(value)));
-            }
+            groupCountRow = new StepperRowState(
+                "Group Count",
+                GroupCountOptions,
+                groups.CurrentCount - NodeGroups.MinCount,
+                i => groups.SetCount(i + NodeGroups.MinCount));
 
-            foreach (var mode in new[] { InputGuideMode.Off, InputGuideMode.DualShock, InputGuideMode.Xbox })
-            {
-                var value = mode;
-                var button = new RectorButtonState($"Guide: {value}", () => guideSettings.SetMode(value));
-                guideButtons.Add((value, button));
-                buttons.Add(button);
-            }
+            guideRow = new SelectorRowState("HUD Guide", i => guideSettings.SetMode(GuideModes[i]));
+
+            rows = new ISettingRow[] { groupCountRow, guideRow };
         }
 
-        public void Initialize()
-        {
-            // 現在値はハイライトで示す。ButtonListPageViewはEnterのたびにボタンを
-            // 作り直すが、RectorButtonStateは使い回されるので状態はここで持てる。
-            disposable = new CompositeDisposable(
-                view.Bind(this),
-                groups.Count.Subscribe(UpdateGroupHighlight),
-                guideSettings.Mode.Subscribe(UpdateGuideHighlight));
-        }
+        public void Initialize() => disposable = view.Bind(this);
 
         public void Dispose() => disposable?.Dispose();
 
@@ -62,53 +58,20 @@ namespace Rector.UI.Hud
         {
             onExit = onExitAction;
 
-            // グループ数の現在値にカーソルを合わせて開く
-            index = groups.CurrentCount - NodeGroups.MinCount;
-            for (var i = 0; i < buttons.Count; i++)
-            {
-                buttons[i].IsFocused.Value = i == index;
-            }
+            // 現在値は開くたびに読み直す。ここ以外から変わっていても表示が嘘にならない。
+            groupCountRow.SetIndexWithoutNotify(groups.CurrentCount - NodeGroups.MinCount);
+            guideRow.SetOptions(GuideOptions, Array.IndexOf(GuideModes, guideSettings.Mode.CurrentValue));
 
             isVisible.Value = true;
         }
 
-        void UpdateGroupHighlight(int count)
+        IReadOnlyList<ISettingRow> ISettingsPageModel.GetRows() => rows;
+
+        void ISettingsPageModel.Cancel()
         {
-            // Guideボタンを巻き込まないようGroupsの区間だけを舐める
-            for (var i = 0; i < GroupButtonCount; i++)
-            {
-                buttons[i].IsHighlighted.Value = i + NodeGroups.MinCount == count;
-            }
-        }
-
-        void UpdateGuideHighlight(InputGuideMode mode)
-        {
-            foreach (var (value, button) in guideButtons)
-            {
-                button.IsHighlighted.Value = value == mode;
-            }
-        }
-
-        IEnumerable<RectorButtonState> IButtonListPageModel.GetButtons() => buttons;
-
-        void IButtonListPageModel.Submit() => buttons[index].OnClick();
-
-        void IButtonListPageModel.Cancel()
-        {
-            buttons[index].IsFocused.Value = false;
             isVisible.Value = false;
             onExit?.Invoke();
             onExit = null;
-        }
-
-        void IButtonListPageModel.Navigate(bool next)
-        {
-            buttons[index].IsFocused.Value = false;
-
-            index += next ? 1 : -1;
-            index = (index + buttons.Count) % buttons.Count;
-
-            buttons[index].IsFocused.Value = true;
         }
     }
 }

--- a/Assets/Rector/Scripts/UI/Hud/HudView.cs
+++ b/Assets/Rector/Scripts/UI/Hud/HudView.cs
@@ -25,10 +25,10 @@ namespace Rector.UI.Hud
         public GraphPage GraphPage { get; }
         public ButtonListPageView ScenePageView { get; }
         public ButtonListPageView SystemPageView { get; }
-        public ButtonListPageView AudioInputDevicePageView { get; }
-        public ButtonListPageView MidiInputDevicePageView { get; }
-        public ButtonListPageView DisplaySettingsPageView { get; }
-        public ButtonListPageView GraphSettingsPageView { get; }
+        public SettingsPageView AudioInputDevicePageView { get; }
+        public SettingsPageView MidiInputDevicePageView { get; }
+        public SettingsPageView DisplaySettingsPageView { get; }
+        public SettingsPageView GraphSettingsPageView { get; }
         public CopyrightNoticesPageView CopyrightNoticesPageView { get; }
 
         public HudView(VisualElement root, UIInputAction uiInputAction, GraphInputAction graphInputAction, NodeTemplateRepository nodeTemplateRepository)
@@ -51,10 +51,10 @@ namespace Rector.UI.Hud
             GraphPage = new GraphPage(root.Q<VisualElement>("graph-page"), graphInputAction, nodeTemplateRepository);
             ScenePageView = new ButtonListPageView(root.Q<VisualElement>("scene-page"), uiInputAction);
             SystemPageView = new ButtonListPageView(root.Q<VisualElement>("system-page"), uiInputAction);
-            AudioInputDevicePageView = new ButtonListPageView(root.Q<VisualElement>("audio-input-device-page"), uiInputAction);
-            MidiInputDevicePageView = new ButtonListPageView(root.Q<VisualElement>("midi-input-device-page"), uiInputAction);
-            DisplaySettingsPageView = new ButtonListPageView(root.Q<VisualElement>("display-settings-page"), uiInputAction);
-            GraphSettingsPageView = new ButtonListPageView(root.Q<VisualElement>("graph-settings-page"), uiInputAction);
+            AudioInputDevicePageView = new SettingsPageView(root.Q<VisualElement>("audio-input-device-page"), uiInputAction);
+            MidiInputDevicePageView = new SettingsPageView(root.Q<VisualElement>("midi-input-device-page"), uiInputAction);
+            DisplaySettingsPageView = new SettingsPageView(root.Q<VisualElement>("display-settings-page"), uiInputAction);
+            GraphSettingsPageView = new SettingsPageView(root.Q<VisualElement>("graph-settings-page"), uiInputAction);
             CopyrightNoticesPageView = new CopyrightNoticesPageView(root.Q<VisualElement>("copyright-notices-page"), uiInputAction);
         }
 

--- a/Assets/Rector/Scripts/UI/Hud/MidiInputDevicePageModel.cs
+++ b/Assets/Rector/Scripts/UI/Hud/MidiInputDevicePageModel.cs
@@ -3,26 +3,28 @@ using System.Collections.Generic;
 using System.Linq;
 using R3;
 using Rector.Midi;
+using Rector.UI.Settings;
 
 namespace Rector.UI.Hud
 {
-    public sealed class MidiInputDevicePageModel : IInitializable, IDisposable, IButtonListPageModel
+    public sealed class MidiInputDevicePageModel : IInitializable, IDisposable, ISettingsPageModel
     {
+        // 左がOff、右がOn。1デバイス1行で、左右キーで受信の入切を変える。
+        static readonly string[] SwitchOptions = { "Off", "On" };
+
         readonly ReactiveProperty<bool> isVisible = new(false);
         readonly MidiInputDeviceManager midiInputDeviceManager;
-        readonly ButtonListPageView view;
-        readonly List<RectorButtonState> buttons = new();
+        readonly SettingsPageView view;
+        readonly List<ISettingRow> rows = new();
         readonly SerialDisposable enterDisposable = new();
         readonly CompositeDisposable disposable = new();
         Action onExit;
 
-        ReadOnlyReactiveProperty<bool> IButtonListPageModel.IsVisible => isVisible;
-        IEnumerable<RectorButtonState> IButtonListPageModel.GetButtons() => buttons;
-
-        int index;
+        ReadOnlyReactiveProperty<bool> ISettingsPageModel.IsVisible => isVisible;
+        IReadOnlyList<ISettingRow> ISettingsPageModel.GetRows() => rows;
 
         public MidiInputDevicePageModel(MidiInputDeviceManager midiInputDeviceManager,
-            ButtonListPageView view)
+            SettingsPageView view)
         {
             this.midiInputDeviceManager = midiInputDeviceManager;
             this.view = view;
@@ -31,12 +33,6 @@ namespace Rector.UI.Hud
         public void Enter(Action onExitAction)
         {
             RefreshDevices();
-
-            index = 0;
-            if (buttons.Count > 0)
-            {
-                buttons[index].IsFocused.Value = true;
-            }
 
             onExit = onExitAction;
             isVisible.Value = true;
@@ -49,50 +45,40 @@ namespace Rector.UI.Hud
 
         void RefreshDevices()
         {
-            buttons.Clear();
+            rows.Clear();
             var d = new CompositeDisposable();
+            var selectedDevices = midiInputDeviceManager.SelectedDevices;
             foreach (var portName in midiInputDeviceManager.GetInputDevices().OrderBy(x => x))
             {
-                var button = new RectorButtonState(portName, () => midiInputDeviceManager.Toggle(portName));
-                buttons.Add(button);
+                var name = portName;
+                var row = new StepperRowState(
+                    name,
+                    SwitchOptions,
+                    Array.IndexOf(selectedDevices.CurrentValue, name) >= 0 ? 1 : 0,
+                    i => midiInputDeviceManager.SetSelected(name, i == 1));
+                rows.Add(row);
 
-                // トグルしてもリストは組み直さないので、ハイライトだけが反応してフォーカスは動かない
-                midiInputDeviceManager.SelectedDevices
-                    .Subscribe(selected => button.IsHighlighted.Value = Array.IndexOf(selected, portName) >= 0)
+                // 入切してもリストは組み直さないので、値だけが追従してフォーカスは動かない
+                selectedDevices
+                    .Subscribe(selected => row.SetIndexWithoutNotify(Array.IndexOf(selected, name) >= 0 ? 1 : 0))
                     .AddTo(d);
             }
 
             // MIDI 機器を挿していないのは日常的に起きる。真っ白なページだと壊れたのと区別が付かない
-            if (buttons.Count == 0)
+            if (rows.Count == 0)
             {
-                buttons.Add(new RectorButtonState("No MIDI Devices", () => { }));
+                rows.Add(new StepperRowState("MIDI Device", new[] { "None" }, 0, _ => { }));
             }
 
             enterDisposable.Disposable = d;
         }
 
-        void IButtonListPageModel.Submit()
-        {
-            if (buttons.Count == 0) return;
-            buttons[index].OnClick();
-        }
-
-        void IButtonListPageModel.Cancel()
+        void ISettingsPageModel.Cancel()
         {
             enterDisposable.Disposable = null;
             isVisible.Value = false;
             onExit?.Invoke();
-        }
-
-        void IButtonListPageModel.Navigate(bool next)
-        {
-            if (buttons.Count == 0) return;
-            buttons[index].IsFocused.Value = false;
-
-            index += next ? 1 : -1;
-            index = (index + buttons.Count) % buttons.Count;
-
-            buttons[index].IsFocused.Value = true;
+            onExit = null;
         }
 
         void IDisposable.Dispose()

--- a/Assets/Rector/Scripts/UI/Hud/SettingsPageView.cs
+++ b/Assets/Rector/Scripts/UI/Hud/SettingsPageView.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using R3;
+using Rector.UI.Settings;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Rector.UI.Hud
+{
+    public interface ISettingsPageModel
+    {
+        IReadOnlyList<ISettingRow> GetRows();
+        ReadOnlyReactiveProperty<bool> IsVisible { get; }
+
+        /// <summary>ページを閉じる。行がメニューを開いている間は呼ばれない。</summary>
+        void Cancel();
+    }
+
+    /// <summary>
+    /// 1設定1行の設定ページ。行カーソルと入力の振り分けだけを持ち、
+    /// 値の持ち方と反映のタイミングは行(<see cref="ISettingRow"/>)に任せる。
+    /// </summary>
+    /// <remarks>
+    /// 「項目を選んで決定する」ページは<see cref="ButtonListPageView"/>のまま。
+    /// こちらは行の上で値を変える形なので、Submitの意味が行ごとに違う。
+    /// </remarks>
+    public sealed class SettingsPageView : IUIInputHandler
+    {
+        const string MenuLayerClassName = "rector-setting-menu-layer";
+
+        readonly VisualElement root;
+        readonly UIInputAction uiInputAction;
+        readonly VisualElement settingList;
+        readonly SerialDisposable inputDisposable = new();
+
+        ISettingsPageModel model;
+        IReadOnlyList<ISettingRow> rows = Array.Empty<ISettingRow>();
+        int index;
+
+        public SettingsPageView(VisualElement root, UIInputAction uiInputAction)
+        {
+            this.root = root;
+            this.uiInputAction = uiInputAction;
+            settingList = root.Q<VisualElement>("setting-list");
+        }
+
+        public IDisposable Bind(ISettingsPageModel page)
+        {
+            model = page;
+            var disposable = new CompositeDisposable();
+
+            page.IsVisible.Subscribe(visible =>
+            {
+                if (visible)
+                    Show();
+                else
+                    Hide();
+            }).AddTo(disposable);
+            inputDisposable.AddTo(disposable);
+            return disposable;
+        }
+
+        void Show()
+        {
+            root.style.display = DisplayStyle.Flex;
+            uiInputAction.Register(this);
+
+            settingList.Clear();
+            rows = model.GetRows();
+            index = 0;
+
+            // UI Toolkitでは階層の後ろにある要素ほど手前に描かれる。展開したメニューが
+            // 下の行に潜らないよう、行を全部並べたあとに専用レイヤーを重ねる。
+            var menuLayer = new VisualElement { pickingMode = PickingMode.Ignore };
+            menuLayer.AddToClassList(MenuLayerClassName);
+
+            var d = new CompositeDisposable();
+            for (var i = 0; i < rows.Count; i++)
+            {
+                var row = rows[i];
+                row.IsFocused.Value = i == index;
+                settingList.Add(CreateElement(row, menuLayer, d));
+            }
+
+            settingList.Add(menuLayer);
+            inputDisposable.Disposable = d;
+        }
+
+        void Hide()
+        {
+            uiInputAction.Unregister(this);
+            root.style.display = DisplayStyle.None;
+            inputDisposable.Disposable = null;
+
+            foreach (var row in rows)
+            {
+                row.IsFocused.Value = false;
+            }
+        }
+
+        static VisualElement CreateElement(ISettingRow row, VisualElement menuLayer, CompositeDisposable disposable)
+        {
+            switch (row)
+            {
+                case StepperRowState stepper:
+                    {
+                        var element = new RectorSettingStepper();
+                        element.Bind(stepper).AddTo(disposable);
+                        return element;
+                    }
+                case SelectorRowState selector:
+                    {
+                        var element = new RectorSettingSelector();
+                        element.Bind(selector, menuLayer).AddTo(disposable);
+                        return element;
+                    }
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(row), row, "unknown setting row");
+            }
+        }
+
+        void IUIInputHandler.OnNavigate(Vector2 value)
+        {
+            if (rows.Count == 0) return;
+
+            // NavigateInputThrottleは優勢な1方向しか流さないので、斜めは来ない
+            var row = rows[index];
+            if (value.y != 0)
+            {
+                var delta = value.y > 0 ? -1 : 1;
+                if (row.IsCapturingInput.CurrentValue)
+                {
+                    row.OnVertical(delta);
+                }
+                else
+                {
+                    MoveCursor(delta);
+                }
+            }
+            else if (value.x != 0)
+            {
+                if (row.IsCapturingInput.CurrentValue) return;
+
+                row.OnHorizontal(value.x > 0 ? 1 : -1);
+            }
+        }
+
+        void MoveCursor(int delta)
+        {
+            rows[index].IsFocused.Value = false;
+            index = (index + delta + rows.Count) % rows.Count;
+            rows[index].IsFocused.Value = true;
+        }
+
+        void IUIInputHandler.OnSubmit()
+        {
+            if (rows.Count == 0) return;
+
+            rows[index].OnSubmit();
+        }
+
+        void IUIInputHandler.OnCancel()
+        {
+            if (rows.Count > 0 && rows[index].IsCapturingInput.CurrentValue)
+            {
+                rows[index].OnCancel();
+                return;
+            }
+
+            model.Cancel();
+        }
+    }
+}

--- a/Assets/Rector/Scripts/UI/Hud/SettingsPageView.cs.meta
+++ b/Assets/Rector/Scripts/UI/Hud/SettingsPageView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4280881dbfd9146d789ea382363f47ed

--- a/Assets/Rector/Scripts/UI/Settings.meta
+++ b/Assets/Rector/Scripts/UI/Settings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: afa40ee8539a247e982d5a5ff1192f7d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Rector/Scripts/UI/Settings/ISettingRow.cs
+++ b/Assets/Rector/Scripts/UI/Settings/ISettingRow.cs
@@ -1,0 +1,35 @@
+using R3;
+
+namespace Rector.UI.Settings
+{
+    /// <summary>
+    /// 設定ページの1行。1行が1つの設定を持つ。
+    /// 候補は表示文字列の並びとして持ち、選択はそのインデックスで扱う。
+    /// インデックスから実際の値への変換はページモデルの責務。
+    /// </summary>
+    public interface ISettingRow
+    {
+        string Label { get; }
+
+        /// <summary>行カーソルが乗っているか。</summary>
+        ReactiveProperty<bool> IsFocused { get; }
+
+        /// <summary>
+        /// 行が上下/Submit/Cancelを占有しているか。メニューを開いている間だけtrueになり、
+        /// ページのカーソル移動と「ページを閉じる」を行が横取りする。
+        /// </summary>
+        ReadOnlyReactiveProperty<bool> IsCapturingInput { get; }
+
+        /// <param name="delta">右が+1、左が-1。</param>
+        void OnHorizontal(int delta);
+
+        /// <summary>占有中のみ呼ばれる。</summary>
+        /// <param name="delta">リストを下へ進むのが+1、上へ戻るのが-1。</param>
+        void OnVertical(int delta);
+
+        void OnSubmit();
+
+        /// <summary>占有中のみ呼ばれる。</summary>
+        void OnCancel();
+    }
+}

--- a/Assets/Rector/Scripts/UI/Settings/ISettingRow.cs.meta
+++ b/Assets/Rector/Scripts/UI/Settings/ISettingRow.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0e5d01f34604c44ef85918ff00f9e427

--- a/Assets/Rector/Scripts/UI/Settings/RectorSettingSelector.cs
+++ b/Assets/Rector/Scripts/UI/Settings/RectorSettingSelector.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using R3;
+using UnityEngine.UIElements;
+
+namespace Rector.UI.Settings
+{
+    /// <summary>
+    /// 「ラベル 値 ▼」の1行。Submitで値の下にメニューが開く。
+    /// メニューは絶対配置で、開いても行そのものは動かさない
+    /// (ステートで位置が動くと目で追えなくなるため)。
+    /// </summary>
+    /// <remarks>
+    /// UI Toolkitに重ね順の指定は無く、階層の後ろにある要素ほど手前に描かれる。
+    /// メニューを自分の子にすると下の行に潜ってしまうので、行より後ろに置かれた
+    /// メニュー専用レイヤーへ預け、開くたびに行の座標へ合わせる。
+    /// </remarks>
+    public sealed class RectorSettingSelector : VisualElement
+    {
+        const string UssClassName = "rector-setting-selector";
+        const string CaretClassName = UssClassName + "__caret";
+        const string CaretExpandedClassName = CaretClassName + "--expanded";
+        const string MenuClassName = UssClassName + "__menu";
+        const string ItemClassName = UssClassName + "__item";
+        const string ItemFocusedClassName = ItemClassName + "--focused";
+
+        readonly Label label = new();
+        readonly Label valueLabel = new();
+        readonly Label caret = new("▼");
+        readonly VisualElement valueColumn = new();
+        readonly VisualElement menu = new();
+        readonly List<Label> items = new();
+
+        SelectorRowState state;
+
+        public RectorSettingSelector()
+        {
+            AddToClassList(SettingRowUss.Row);
+            AddToClassList(UssClassName);
+            pickingMode = PickingMode.Ignore;
+
+            label.AddToClassList(SettingRowUss.Label);
+            Add(label);
+
+            valueColumn.pickingMode = PickingMode.Ignore;
+            valueColumn.AddToClassList(SettingRowUss.Value);
+            valueLabel.AddToClassList(SettingRowUss.ValueLabel);
+            caret.AddToClassList(CaretClassName);
+            menu.AddToClassList(MenuClassName);
+            menu.pickingMode = PickingMode.Ignore;
+            valueColumn.Add(valueLabel);
+            valueColumn.Add(caret);
+            Add(valueColumn);
+
+            // 行のレイアウトが決まる/変わるたびに合わせ直す。開いた瞬間だけ計算すると、
+            // まだレイアウトが解決していないフレームで開かれたときに座標がNaNになる。
+            RegisterCallback<GeometryChangedEvent>(_ => PlaceMenu());
+        }
+
+        /// <param name="menuLayer">
+        /// 行より後ろに置かれた、行と同じ座標系のレイヤー。メニューはここに描く。
+        /// </param>
+        public IDisposable Bind(SelectorRowState rowState, VisualElement menuLayer)
+        {
+            state = rowState;
+            label.text = rowState.Label;
+            menuLayer.Add(menu);
+
+            // 候補 → 確定値 → カーソル の順に張る。候補が入れ替わったあとで
+            // 現在値とカーソルを塗り直せるよう、RebuildItemsも両方を呼び直す。
+            return new CompositeDisposable(
+                rowState.IsFocused.Subscribe(x => EnableInClassList(SettingRowUss.RowFocused, x)),
+                rowState.Options.Subscribe(_ => RebuildItems()),
+                rowState.SelectedIndex.Subscribe(_ => UpdateValue()),
+                rowState.CursorIndex.Subscribe(_ => UpdateCursor()),
+                rowState.IsExpanded.Subscribe(x =>
+                {
+                    if (x) PlaceMenu();
+                    menu.style.display = x ? DisplayStyle.Flex : DisplayStyle.None;
+                    caret.EnableInClassList(CaretExpandedClassName, x);
+                }));
+        }
+
+        /// <summary>メニューを値の列の真下に合わせる。</summary>
+        void PlaceMenu()
+        {
+            var rowLayout = layout;
+            var valueLayout = valueColumn.layout;
+            if (float.IsNaN(rowLayout.x) || float.IsNaN(valueLayout.x)) return;
+
+            menu.style.left = rowLayout.x + valueLayout.x;
+            menu.style.top = rowLayout.yMax;
+            menu.style.width = valueLayout.width;
+        }
+
+        void RebuildItems()
+        {
+            menu.Clear();
+            items.Clear();
+
+            foreach (var text in state.Options.CurrentValue)
+            {
+                var item = new Label(text) { pickingMode = PickingMode.Ignore };
+                item.AddToClassList(ItemClassName);
+                menu.Add(item);
+                items.Add(item);
+            }
+
+            UpdateValue();
+            UpdateCursor();
+        }
+
+        // 現在値はメニューの上の値ラベルに出ているので、メニューの中では印を付けない
+        void UpdateValue()
+        {
+            var options = state.Options.CurrentValue;
+            var index = state.SelectedIndex.CurrentValue;
+            valueLabel.text = index >= 0 && index < options.Count ? options[index] : string.Empty;
+        }
+
+        void UpdateCursor()
+        {
+            var index = state.CursorIndex.CurrentValue;
+            for (var i = 0; i < items.Count; i++)
+            {
+                items[i].EnableInClassList(ItemFocusedClassName, i == index);
+            }
+        }
+    }
+}

--- a/Assets/Rector/Scripts/UI/Settings/RectorSettingSelector.cs.meta
+++ b/Assets/Rector/Scripts/UI/Settings/RectorSettingSelector.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2a250640dfd73491180e3952aa359351

--- a/Assets/Rector/Scripts/UI/Settings/RectorSettingStepper.cs
+++ b/Assets/Rector/Scripts/UI/Settings/RectorSettingStepper.cs
@@ -1,0 +1,54 @@
+using System;
+using R3;
+using UnityEngine.UIElements;
+
+namespace Rector.UI.Settings
+{
+    /// <summary>
+    /// 「ラベル ◁ 値 ▷」の1行。これ以上送れない側の矢印を減光して行き止まりを見せる。
+    /// </summary>
+    public sealed class RectorSettingStepper : VisualElement
+    {
+        const string UssClassName = "rector-setting-stepper";
+        const string ArrowClassName = UssClassName + "__arrow";
+        const string ArrowDisabledClassName = ArrowClassName + "--disabled";
+
+        readonly Label label = new();
+        readonly Label valueLabel = new();
+        readonly Label leftArrow = new("◁");
+        readonly Label rightArrow = new("▷");
+
+        public RectorSettingStepper()
+        {
+            AddToClassList(SettingRowUss.Row);
+            AddToClassList(UssClassName);
+            pickingMode = PickingMode.Ignore;
+
+            label.AddToClassList(SettingRowUss.Label);
+            Add(label);
+
+            var value = new VisualElement { pickingMode = PickingMode.Ignore };
+            value.AddToClassList(SettingRowUss.Value);
+            leftArrow.AddToClassList(ArrowClassName);
+            valueLabel.AddToClassList(SettingRowUss.ValueLabel);
+            rightArrow.AddToClassList(ArrowClassName);
+            value.Add(leftArrow);
+            value.Add(valueLabel);
+            value.Add(rightArrow);
+            Add(value);
+        }
+
+        public IDisposable Bind(StepperRowState state)
+        {
+            label.text = state.Label;
+            return new CompositeDisposable(
+                state.IsFocused.Subscribe(x => EnableInClassList(SettingRowUss.RowFocused, x)),
+                state.SelectedIndex.Subscribe(index =>
+                {
+                    valueLabel.text = index >= 0 && index < state.Options.Count ? state.Options[index] : string.Empty;
+                    leftArrow.EnableInClassList(ArrowDisabledClassName, index <= 0);
+                    rightArrow.EnableInClassList(ArrowDisabledClassName, index >= state.Options.Count - 1);
+                }));
+        }
+    }
+}

--- a/Assets/Rector/Scripts/UI/Settings/RectorSettingStepper.cs.meta
+++ b/Assets/Rector/Scripts/UI/Settings/RectorSettingStepper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b93fe6a43c0b84e839dd01a713de71b7

--- a/Assets/Rector/Scripts/UI/Settings/SelectorRowState.cs
+++ b/Assets/Rector/Scripts/UI/Settings/SelectorRowState.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using R3;
+using UnityEngine;
+
+namespace Rector.UI.Settings
+{
+    /// <summary>
+    /// Submitでメニューを開き、上下で候補を選んでもう一度Submitで確定する行。
+    /// 解像度のように「送るたびに反映する」とウィンドウが跳ねてしまう設定に使う。
+    /// メニューを閉じるまで値は適用しない。
+    /// </summary>
+    public sealed class SelectorRowState : ISettingRow
+    {
+        public string Label { get; }
+        public ReactiveProperty<bool> IsFocused { get; } = new(false);
+
+        readonly ReactiveProperty<IReadOnlyList<string>> options = new(Array.Empty<string>());
+        public ReadOnlyReactiveProperty<IReadOnlyList<string>> Options => options;
+
+        /// <summary>確定済みの値。まだ選ばれていないとき(候補が空、現在値が候補に無い)は-1。</summary>
+        readonly ReactiveProperty<int> selectedIndex = new(-1);
+        public ReadOnlyReactiveProperty<int> SelectedIndex => selectedIndex;
+
+        /// <summary>メニューを開いている間のカーソル。確定せずに閉じたら捨てる。</summary>
+        readonly ReactiveProperty<int> cursorIndex = new(0);
+        public ReadOnlyReactiveProperty<int> CursorIndex => cursorIndex;
+
+        readonly ReactiveProperty<bool> isExpanded = new(false);
+        public ReadOnlyReactiveProperty<bool> IsExpanded => isExpanded;
+        ReadOnlyReactiveProperty<bool> ISettingRow.IsCapturingInput => isExpanded;
+
+        readonly Action<int> onCommit;
+
+        public SelectorRowState(string label, Action<int> onCommit)
+        {
+            Label = label;
+            this.onCommit = onCommit;
+        }
+
+        /// <summary>
+        /// 候補と現在値を差し替える。解像度や入力デバイスは環境で変わるので、ページを開くたびに読み直す。
+        /// </summary>
+        /// <param name="selected">現在値の位置。まだ選ばれていなければ負の値を渡す。</param>
+        public void SetOptions(IReadOnlyList<string> values, int selected)
+        {
+            isExpanded.Value = false;
+            options.Value = values;
+            // 選ばれていないときに先頭へ丸めると、選んでいない値を現在値として見せることになる
+            selectedIndex.Value = values.Count == 0 || selected < 0 ? -1 : Mathf.Min(selected, values.Count - 1);
+            cursorIndex.Value = Mathf.Max(selectedIndex.Value, 0);
+        }
+
+        void ISettingRow.OnHorizontal(int delta)
+        {
+            // 送るたびに反映されるのを避けるための行なので、左右では動かさない
+        }
+
+        void ISettingRow.OnVertical(int delta)
+        {
+            var count = options.Value.Count;
+            if (count == 0) return;
+
+            // 候補の多い解像度リストを端から端へ移れるよう、カーソルは巡回させる
+            cursorIndex.Value = ((cursorIndex.Value + Math.Sign(delta)) % count + count) % count;
+        }
+
+        void ISettingRow.OnSubmit()
+        {
+            if (options.Value.Count == 0) return;
+
+            if (!isExpanded.Value)
+            {
+                cursorIndex.Value = Mathf.Max(selectedIndex.Value, 0);
+                isExpanded.Value = true;
+                return;
+            }
+
+            isExpanded.Value = false;
+
+            // 現在値を選び直しただけなら適用しない。同じ解像度でも適用すると画面が一度跳ねるため。
+            if (cursorIndex.Value == selectedIndex.Value) return;
+
+            selectedIndex.Value = cursorIndex.Value;
+            onCommit(selectedIndex.Value);
+        }
+
+        void ISettingRow.OnCancel() => isExpanded.Value = false;
+    }
+}

--- a/Assets/Rector/Scripts/UI/Settings/SelectorRowState.cs.meta
+++ b/Assets/Rector/Scripts/UI/Settings/SelectorRowState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f6e9f2d9487d14e5a9712370798e34fb

--- a/Assets/Rector/Scripts/UI/Settings/SettingRowUss.cs
+++ b/Assets/Rector/Scripts/UI/Settings/SettingRowUss.cs
@@ -1,0 +1,15 @@
+namespace Rector.UI.Settings
+{
+    /// <summary>
+    /// 設定行の共通USSクラス名。ステッパーとセレクターでラベル列と値列の骨格を揃え、
+    /// 行の種類が変わっても値の位置が動かないようにする。
+    /// </summary>
+    public static class SettingRowUss
+    {
+        public const string Row = "rector-setting-row";
+        public const string RowFocused = Row + "--focused";
+        public const string Label = Row + "__label";
+        public const string Value = Row + "__value";
+        public const string ValueLabel = Row + "__value-label";
+    }
+}

--- a/Assets/Rector/Scripts/UI/Settings/SettingRowUss.cs.meta
+++ b/Assets/Rector/Scripts/UI/Settings/SettingRowUss.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c2e9ed55979844fe387dbe1962ac4131

--- a/Assets/Rector/Scripts/UI/Settings/StepperRowState.cs
+++ b/Assets/Rector/Scripts/UI/Settings/StepperRowState.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using R3;
+using UnityEngine;
+
+namespace Rector.UI.Settings
+{
+    /// <summary>
+    /// 左右キーで候補を送り、送った先をその場で反映する行。
+    /// グループ数やガイド表記のように、切り替えても画面が跳ねない設定に使う。
+    /// </summary>
+    /// <remarks>
+    /// 端では巡回せずclampする。巡回すると押しっぱなしのまま8→1のように値が飛び、
+    /// 押した長さと結果が結びつかなくなるため。端に着いたことは矢印の減光で見せる。
+    /// </remarks>
+    public sealed class StepperRowState : ISettingRow
+    {
+        public string Label { get; }
+        public IReadOnlyList<string> Options { get; }
+        public ReactiveProperty<bool> IsFocused { get; } = new(false);
+
+        readonly ReactiveProperty<int> selectedIndex;
+        public ReadOnlyReactiveProperty<int> SelectedIndex => selectedIndex;
+
+        // ステッパーは入力を常にページへ返すので、占有することはない
+        readonly ReactiveProperty<bool> isCapturingInput = new(false);
+        ReadOnlyReactiveProperty<bool> ISettingRow.IsCapturingInput => isCapturingInput;
+
+        readonly Action<int> onChanged;
+
+        public StepperRowState(string label, IReadOnlyList<string> options, int selectedIndex, Action<int> onChanged)
+        {
+            Label = label;
+            Options = options;
+            this.selectedIndex = new ReactiveProperty<int>(Clamp(selectedIndex, options.Count));
+            this.onChanged = onChanged;
+        }
+
+        /// <summary>設定の実体が外から変わったときに、onChangedを呼ばずに表示だけ合わせる。</summary>
+        public void SetIndexWithoutNotify(int index) => selectedIndex.Value = Clamp(index, Options.Count);
+
+        void ISettingRow.OnHorizontal(int delta)
+        {
+            var next = Clamp(selectedIndex.Value + Math.Sign(delta), Options.Count);
+            if (next == selectedIndex.Value) return;
+
+            selectedIndex.Value = next;
+            onChanged(next);
+        }
+
+        void ISettingRow.OnVertical(int delta)
+        {
+        }
+
+        void ISettingRow.OnSubmit()
+        {
+        }
+
+        void ISettingRow.OnCancel()
+        {
+        }
+
+        static int Clamp(int index, int count) => count == 0 ? 0 : Mathf.Clamp(index, 0, count - 1);
+    }
+}

--- a/Assets/Rector/Scripts/UI/Settings/StepperRowState.cs.meta
+++ b/Assets/Rector/Scripts/UI/Settings/StepperRowState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 63129add5982b4f5e976701ce1fff569

--- a/Assets/Rector/StaticResources/UI/Hud.uxml
+++ b/Assets/Rector/StaticResources/UI/Hud.uxml
@@ -34,16 +34,16 @@
                 <engine:VisualElement name="left-list" class="rector-button-list" />
             </engine:VisualElement>
             <engine:VisualElement name="audio-input-device-page" class="rector-page">
-                <engine:VisualElement name="left-list" class="rector-button-list" />
+                <engine:VisualElement name="setting-list" class="rector-setting-list" />
             </engine:VisualElement>
             <engine:VisualElement name="midi-input-device-page" class="rector-page">
-                <engine:VisualElement name="left-list" class="rector-button-list" />
+                <engine:VisualElement name="setting-list" class="rector-setting-list" />
             </engine:VisualElement>
             <engine:VisualElement name="display-settings-page" class="rector-page">
-                <engine:VisualElement name="left-list" class="rector-button-list" />
+                <engine:VisualElement name="setting-list" class="rector-setting-list" />
             </engine:VisualElement>
             <engine:VisualElement name="graph-settings-page" class="rector-page">
-                <engine:VisualElement name="left-list" class="rector-button-list" />
+                <engine:VisualElement name="setting-list" class="rector-setting-list" />
             </engine:VisualElement>
             <engine:VisualElement name="copyright-notices-page" class="rector-page rector-copyright-notices-page">
                 <engine:Label name="copyright-notices-label" class="rector-copyright-notices-label" />

--- a/Assets/Rector/StaticResources/UI/StyleSheets/RectorCommon.uss
+++ b/Assets/Rector/StaticResources/UI/StyleSheets/RectorCommon.uss
@@ -43,6 +43,131 @@
     -unity-text-align: middle-center;
 }
 
+/* 設定ページの1行。ラベル列と値列の2カラムで、値列の左端は行の種類が変わっても動かない。 */
+.rector-setting-row {
+    flex-direction: row;
+    align-items: center;
+    border-width: 1px;
+    border-color: rgba(0, 0, 0, 0);
+    margin-bottom: 2px;
+}
+
+.rector-setting-row--focused {
+    border-color: var(--rector-border-color);
+}
+
+/*
+ * 2列の幅は、どのページでも同じ配分で決める。MIDIはポート名がラベルに、
+ * Audioはデバイス名が値に来るので、どちらの列も長くなりうる。
+ * 全行が同じ規則で割るため、列の境目はページ内で必ず揃う。
+ */
+.rector-setting-row__label {
+    flex-grow: 1;
+    flex-shrink: 1;
+    flex-basis: 320px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    color: var(--rector-text-color);
+    background-color: var(--rector-text-background-color);
+    margin: 0;
+    padding: 0 8px;
+    -unity-text-align: middle-left;
+}
+
+.rector-setting-row__value {
+    flex-direction: row;
+    align-items: center;
+    flex-grow: 1;
+    flex-shrink: 1;
+    flex-basis: 400px;
+    background-color: var(--rector-text-background-color);
+    /* メニューを絶対配置でぶら下げるための基準 */
+    position: relative;
+}
+
+.rector-setting-row__value-label {
+    flex-grow: 1;
+    flex-shrink: 1;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    color: var(--rector-text-color);
+    margin: 0;
+    padding: 0;
+    -unity-text-align: middle-center;
+}
+
+/* フォーカスは枠 + 中身の黒背景。rector-button と同じ見せ方に揃える */
+.rector-setting-row--focused .rector-setting-row__label,
+.rector-setting-row--focused .rector-setting-row__value {
+    background-color: black;
+}
+
+/* ステッパー: これ以上送れない側の矢印を減光して行き止まりを見せる */
+.rector-setting-stepper__arrow {
+    width: 16px;
+    color: var(--rector-text-color);
+    margin: 0;
+    padding: 0;
+    -unity-text-align: middle-center;
+}
+
+.rector-setting-stepper__arrow--disabled {
+    opacity: 0.25;
+}
+
+/* セレクター: メニューは値列の下に絶対配置し、開いても行を押し出さない */
+.rector-setting-selector__caret {
+    width: 16px;
+    color: var(--rector-text-color);
+    margin: 0;
+    padding: 0;
+    -unity-text-align: middle-center;
+}
+
+.rector-setting-selector__caret--expanded {
+    color: rgba(255, 255, 255, 0.9);
+}
+
+/* 行を全部並べたあとに重ねる、メニュー専用の面。行と同じ座標系にする */
+.rector-setting-menu-layer {
+    position: absolute;
+    left: 0;
+    top: 0;
+    right: 0;
+    bottom: 0;
+}
+
+/*
+ * 位置と幅は行に合わせてコードから入れる。
+ * 下の行に重なるので半透明にはできないが、黒はフォーカスの色なので使わない。
+ * 下地は不透明のダークグレーにして、黒は中のカーソルだけに残す。
+ */
+.rector-setting-selector__menu {
+    position: absolute;
+    display: none;
+    background-color: rgb(26, 26, 26);
+    border-width: 1px;
+    border-color: var(--rector-border-color);
+}
+
+/* 候補は行の値と同じ中央揃え。メニューは値の列と同じ幅なので、真上の現在値と中心が揃う */
+.rector-setting-selector__item {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    color: var(--rector-text-color);
+    margin: 0;
+    padding: 1px 8px;
+    -unity-text-align: middle-center;
+}
+
+.rector-setting-selector__item--focused {
+    color: rgba(255, 255, 255, 0.9);
+    background-color: black;
+}
+
 .rector-slider {
     flex-grow: 1;
 }

--- a/Assets/Rector/StaticResources/UI/StyleSheets/RectorStyles.uss
+++ b/Assets/Rector/StaticResources/UI/StyleSheets/RectorStyles.uss
@@ -145,6 +145,14 @@
     margin-top: 100px;
 }
 
+/* 行の幅を固定して、どのページでも値の列が同じ位置に来るようにする */
+.rector-setting-list {
+    align-items: stretch;
+    width: 760px;
+    margin-left: 100px;
+    margin-top: 100px;
+}
+
 .rector-copyright-notices-page {
     width: 100%;
     height: 100%;

--- a/Assets/Rector/Tests/EditMode/SettingRowStateTests.cs
+++ b/Assets/Rector/Tests/EditMode/SettingRowStateTests.cs
@@ -1,0 +1,177 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using Rector.UI.Settings;
+
+namespace Rector.Tests.EditMode
+{
+    /// <summary>
+    /// 設定行の状態遷移のテスト。
+    /// ステッパーは端でclampして値を飛ばさないこと、
+    /// セレクターはメニューを閉じるまで値を適用しないことが要。
+    /// </summary>
+    public sealed class SettingRowStateTests
+    {
+        static readonly string[] Three = { "a", "b", "c" };
+
+        [Test]
+        public void Stepper_ClampsAtBothEnds()
+        {
+            var changed = new List<int>();
+            var stepper = new StepperRowState("label", Three, 0, changed.Add);
+            ISettingRow row = stepper;
+
+            row.OnHorizontal(-1);
+            Assert.AreEqual(0, stepper.SelectedIndex.CurrentValue);
+            CollectionAssert.IsEmpty(changed);
+
+            row.OnHorizontal(1);
+            row.OnHorizontal(1);
+            row.OnHorizontal(1);
+            Assert.AreEqual(2, stepper.SelectedIndex.CurrentValue);
+            CollectionAssert.AreEqual(new[] { 1, 2 }, changed);
+        }
+
+        [Test]
+        public void Stepper_NeverCapturesInput()
+        {
+            ISettingRow row = new StepperRowState("label", Three, 0, _ => { });
+
+            row.OnSubmit();
+            Assert.IsFalse(row.IsCapturingInput.CurrentValue);
+        }
+
+        [Test]
+        public void Stepper_SetIndexWithoutNotify_DoesNotInvokeCallback()
+        {
+            var changed = new List<int>();
+            var stepper = new StepperRowState("label", Three, 0, changed.Add);
+
+            stepper.SetIndexWithoutNotify(2);
+
+            Assert.AreEqual(2, stepper.SelectedIndex.CurrentValue);
+            CollectionAssert.IsEmpty(changed);
+        }
+
+        [Test]
+        public void Selector_CommitsOnlyOnSubmitInsideMenu()
+        {
+            var committed = new List<int>();
+            var selector = new SelectorRowState("label", committed.Add);
+            selector.SetOptions(Three, 0);
+            ISettingRow row = selector;
+
+            // 閉じている間は左右も上下も値を動かさない
+            row.OnHorizontal(1);
+            row.OnVertical(1);
+            Assert.AreEqual(0, selector.SelectedIndex.CurrentValue);
+            CollectionAssert.IsEmpty(committed);
+
+            row.OnSubmit();
+            Assert.IsTrue(selector.IsExpanded.CurrentValue);
+            Assert.IsTrue(row.IsCapturingInput.CurrentValue);
+
+            row.OnVertical(1);
+            Assert.AreEqual(1, selector.CursorIndex.CurrentValue);
+            Assert.AreEqual(0, selector.SelectedIndex.CurrentValue, "確定するまで値は動かない");
+            CollectionAssert.IsEmpty(committed);
+
+            row.OnSubmit();
+            Assert.IsFalse(selector.IsExpanded.CurrentValue);
+            Assert.AreEqual(1, selector.SelectedIndex.CurrentValue);
+            CollectionAssert.AreEqual(new[] { 1 }, committed);
+        }
+
+        [Test]
+        public void Selector_CancelDiscardsCursor()
+        {
+            var committed = new List<int>();
+            var selector = new SelectorRowState("label", committed.Add);
+            selector.SetOptions(Three, 0);
+            ISettingRow row = selector;
+
+            row.OnSubmit();
+            row.OnVertical(1);
+            row.OnCancel();
+
+            Assert.IsFalse(selector.IsExpanded.CurrentValue);
+            Assert.AreEqual(0, selector.SelectedIndex.CurrentValue);
+            CollectionAssert.IsEmpty(committed);
+
+            // 開き直したらカーソルは現在値に戻る
+            row.OnSubmit();
+            Assert.AreEqual(0, selector.CursorIndex.CurrentValue);
+        }
+
+        [Test]
+        public void Selector_CursorWrapsAround()
+        {
+            var selector = new SelectorRowState("label", _ => { });
+            selector.SetOptions(Three, 0);
+            ISettingRow row = selector;
+
+            row.OnSubmit();
+            row.OnVertical(-1);
+            Assert.AreEqual(2, selector.CursorIndex.CurrentValue);
+
+            row.OnVertical(1);
+            Assert.AreEqual(0, selector.CursorIndex.CurrentValue);
+        }
+
+        [Test]
+        public void Selector_ReSelectingCurrentValueDoesNotCommit()
+        {
+            var committed = new List<int>();
+            var selector = new SelectorRowState("label", committed.Add);
+            selector.SetOptions(Three, 1);
+            ISettingRow row = selector;
+
+            row.OnSubmit();
+            row.OnSubmit();
+
+            Assert.IsFalse(selector.IsExpanded.CurrentValue);
+            Assert.AreEqual(1, selector.SelectedIndex.CurrentValue);
+            CollectionAssert.IsEmpty(committed);
+        }
+
+        [Test]
+        public void Selector_WithoutOptions_DoesNotExpand()
+        {
+            var selector = new SelectorRowState("label", _ => { });
+            ISettingRow row = selector;
+
+            row.OnSubmit();
+
+            Assert.IsFalse(selector.IsExpanded.CurrentValue);
+            Assert.AreEqual(-1, selector.SelectedIndex.CurrentValue);
+        }
+
+        [Test]
+        public void Selector_SetOptions_KeepsUnselectedAsUnselected()
+        {
+            var selector = new SelectorRowState("label", _ => { });
+
+            // 現在値が候補に無いときに先頭へ丸めると、選んでいない値を現在値として見せてしまう
+            selector.SetOptions(Three, -1);
+
+            Assert.AreEqual(-1, selector.SelectedIndex.CurrentValue);
+            Assert.AreEqual(0, selector.CursorIndex.CurrentValue);
+        }
+
+        [Test]
+        public void Selector_SetOptions_ClosesMenuAndClampsSelection()
+        {
+            var selector = new SelectorRowState("label", _ => { });
+            selector.SetOptions(Three, 2);
+            ISettingRow row = selector;
+
+            row.OnSubmit();
+            Assert.IsTrue(selector.IsExpanded.CurrentValue);
+
+            selector.SetOptions(new[] { "x", "y" }, 5);
+
+            Assert.IsFalse(selector.IsExpanded.CurrentValue);
+            Assert.AreEqual(1, selector.SelectedIndex.CurrentValue);
+            Assert.AreEqual(1, selector.CursorIndex.CurrentValue);
+        }
+    }
+}

--- a/Assets/Rector/Tests/EditMode/SettingRowStateTests.cs.meta
+++ b/Assets/Rector/Tests/EditMode/SettingRowStateTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0bf5644e322ec4b5cb086d1a36f70f5e


### PR DESCRIPTION
Closes #69

Settings pages laid out one button per value, so a page grew a row for every candidate. Graph settings took 11 rows for 2 settings, and Display settings took 4 rows plus one per resolution. Each setting now gets a single row, with the value on that row.

## Two kinds of row

Picked by what the value costs to apply.

| Row | Operation | Used by |
|---|---|---|
| `StepperRowState` / `RectorSettingStepper` | left/right sends the value and applies it on the spot | Group count, MIDI device on/off |
| `SelectorRowState` / `RectorSettingSelector` | Submit opens a menu, up/down picks, Submit commits | Screen mode, Resolution, HUD guide, audio input device |

The stepper clamps at both ends rather than wrapping, so holding the key cannot jump 8 to 1; the end is shown by dimming that side's arrow. The selector holds its value until Submit inside the menu, so scrolling the resolution list does not bounce the window on every step.

```
Group Count    ◁  4  ▷
HUD Guide      Xbox        ▼
```

## Structure

`SettingsPageView` holds the row cursor and routes input, which removes the index bookkeeping each page model used to carry. Menus are drawn on a layer placed after the rows: UI Toolkit has no z-order, so a menu parented to its own row is painted under the rows below it.

Pages converted: Graph, Display, Audio input device, MIDI input device. Scene and System stay on `ButtonListPageView` since they pick an item rather than set a value.

## Also in here

- Display settings reads the current mode and resolution from `Screen` when the page opens, instead of always starting the cursor at the first entry. Resolutions are de-duplicated by width and height (the refresh rate is fixed at 60 when applying), and a current size that is not in the list is added so the row never shows a value that is not in effect.
- `MidiInputDeviceManager.SetSelected` lets a row drive the port to a given state instead of toggling blind.

## Out of scope

- The input guide for settings pages (the "要検討" item on the issue).
- The resolution menu is still as tall as the candidate list. Left as is for now.

## Verification

- `unity command recompile` clean, EditMode tests 29/29 (`SettingRowStateTests` covers stepper clamping and the selector holding its value until Submit).
- Each page driven in play mode through `IUIInputHandler` and read back from the visual tree: row values, focus classes, menu placement and colors, MIDI toggling, resolution de-duplication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
