### PR TITLE
add: save and load the node graph (issue #81)

### DIFF
--- a/Assets/Rector/Scripts/BGScene.cs
+++ b/Assets/Rector/Scripts/BGScene.cs
@@ -33,7 +33,7 @@ namespace Rector
             {
                 var proxy = proxyRepository.GetOrCreateProxy(nodeBehaviour);
                 var category = nodeBehaviour.Category;
-                var template = NodeTemplate.Create(category, nodeBehaviour.name, id =>
+                var template = NodeTemplate.SceneLocal(nodeBehaviour.Guid, category, nodeBehaviour.name, id =>
                 {
                     var node = new BehaviourNode(id, proxy);
                     var ve = VisualElementFactory.Instance.CreateNode();

--- a/Assets/Rector/Scripts/Cli/CliClient.Commands.cs
+++ b/Assets/Rector/Scripts/Cli/CliClient.Commands.cs
@@ -79,6 +79,24 @@ namespace Rector.Cli
         [CliCommand("rector_sort_graph", "Re-run the layered graph layout.")]
         static object SortGraphCommand() => Call(c => c.SortGraph());
 
+        [CliCommand("rector_graph_slots", "Graph save slots: how many nodes and edges each holds, and when it was saved.")]
+        static object GraphSlotsCommand() => Call(c => c.GetGraphSlots());
+
+        [CliCommand("rector_save_graph", "Save the current graph to a slot, overwriting whatever is there.")]
+        static object SaveGraphCommand(
+            [CliArg("slot", "Slot number, 1..8.", Required = true)] int slot)
+            => Call(c => c.SaveGraph(slot));
+
+        [CliCommand("rector_load_graph", "Add a saved slot's nodes and edges to the current graph. Existing nodes are untouched.")]
+        static object LoadGraphCommand(
+            [CliArg("slot", "Slot number, 1..8.", Required = true)] int slot)
+            => Call(c => c.LoadGraph(slot));
+
+        [CliCommand("rector_clear_graph", "Remove every node and edge. Not undoable: requires confirm=true.")]
+        static object ClearGraphCommand(
+            [CliArg("confirm", "Apply the removal. Without it the call is refused.")] bool confirm = false)
+            => Call(c => c.ClearGraph(confirm));
+
         [CliCommand("rector_load_scene", "Load a background scene by name.")]
         static object LoadSceneCommand(
             [CliArg("name", "Scene name, as listed by rector_scenes.", Required = true)] string name)

--- a/Assets/Rector/Scripts/Cli/CliClient.cs
+++ b/Assets/Rector/Scripts/Cli/CliClient.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Rector.Cameras;
 using Rector.UI.GraphPages;
 using Rector.UI.Graphs;
+using Rector.UI.Graphs.Serialization;
 using Rector.UI.Graphs.Slots;
 using Rector.UI.LayeredGraphDrawing;
 using Rector.Vfx;
@@ -32,19 +33,22 @@ namespace Rector.Cli
         readonly VfxManager vfxManager;
         readonly CameraManager cameraManager;
         readonly BGSceneManager bgSceneManager;
+        readonly GraphSaveManager graphSaveManager;
 
         public CliClient(
             GraphPage graphPage,
             NodeTemplateRepository nodeTemplateRepository,
             VfxManager vfxManager,
             CameraManager cameraManager,
-            BGSceneManager bgSceneManager)
+            BGSceneManager bgSceneManager,
+            GraphSaveManager graphSaveManager)
         {
             this.graphPage = graphPage;
             this.nodeTemplateRepository = nodeTemplateRepository;
             this.vfxManager = vfxManager;
             this.cameraManager = cameraManager;
             this.bgSceneManager = bgSceneManager;
+            this.graphSaveManager = graphSaveManager;
         }
 
         public void Dispose()
@@ -205,6 +209,72 @@ namespace Rector.Cli
             graphPage.Sort();
             return new { success = true, nodeCount = graphPage.Graph.NodeCount, edgeCount = graphPage.Graph.EdgeCount };
         }
+
+        // ------------------------------------------------------ グラフの保存 / 読み込み
+
+        object GetGraphSlots() => new
+        {
+            slots = graphSaveManager.GetAllSlotInfo()
+                .Select(s => new { slot = s.Number, empty = s.IsEmpty, nodeCount = s.NodeCount, edgeCount = s.EdgeCount, savedAt = s.SavedAt })
+                .ToArray(),
+        };
+
+        object SaveGraph(int slot)
+        {
+            if (!GraphSlotRepository.IsValidSlot(slot)) return InvalidSlot(slot);
+
+            if (!graphSaveManager.Save(slot, out var result))
+                return Failure("save_failed", $"Could not write graph slot {slot}. See the Unity log.");
+
+            // skipped は BG シーン由来のノードとその端点のエッジ。今は保存の対象外 (issue #81)
+            return new
+            {
+                success = true,
+                slot,
+                nodeCount = result.NodeCount,
+                edgeCount = result.EdgeCount,
+                skippedNodeCount = result.SkippedNodeCount,
+                skippedEdgeCount = result.SkippedEdgeCount,
+            };
+        }
+
+        // ロードは今のグラフへ足すだけで何も失わないので、confirm は要らない。
+        // 丸ごと入れ替えたいときは rector_clear_graph を先に呼ぶ。
+        object LoadGraph(int slot)
+        {
+            if (!GraphSlotRepository.IsValidSlot(slot)) return InvalidSlot(slot);
+
+            if (!graphSaveManager.Load(slot, out var result))
+                return Failure("empty_slot", $"Graph slot {slot} is empty or unreadable.");
+
+            return new
+            {
+                success = true,
+                slot,
+                addedNodeCount = result.NodeCount,
+                addedEdgeCount = result.EdgeCount,
+                skippedNodeCount = result.SkippedNodeCount,
+                skippedEdgeCount = result.SkippedEdgeCount,
+                nodeCount = graphPage.Graph.NodeCount,
+                edgeCount = graphPage.Graph.EdgeCount,
+            };
+        }
+
+        object ClearGraph(bool confirm)
+        {
+            var nodeCount = graphPage.Graph.NodeCount;
+
+            // HUD 側も2度押しを要求する操作。undo が無いので CLI からも一手間かける
+            if (nodeCount > 0 && !confirm)
+                return Failure("confirm_required", $"Clearing the graph removes {nodeCount} node(s) and cannot be undone. Pass confirm=true.");
+
+            graphPage.ClearGraph();
+            RectorLogger.GraphCleared(nodeCount);
+            return new { success = true, removed = nodeCount };
+        }
+
+        static object InvalidSlot(int slot) =>
+            Failure("slot_out_of_range", $"Graph slot must be in [1, {GraphSlotRepository.SlotCount}]. Got {slot}.");
 
         // ------------------------------------------------------ シーン / カメラ / VFX
 

--- a/Assets/Rector/Scripts/RectorInstaller.cs
+++ b/Assets/Rector/Scripts/RectorInstaller.cs
@@ -10,6 +10,7 @@ using Rector.Osc;
 using Rector.UI;
 using Rector.UI.GraphPages;
 using Rector.UI.Graphs;
+using Rector.UI.Graphs.Serialization;
 using Rector.UI.Hud;
 using Rector.Vfx;
 using Unity.Cinemachine;
@@ -82,6 +83,8 @@ namespace Rector
             var oscSettingsPage = Register(new OscSettingsPageModel(oscInputSetting, oscModel, hudView.OscSettingsPageView));
             var displaySettingsPage = Register(new DisplaySettingsPageModel(hudView.DisplaySettingsPageView));
             var graphSettingsPage = Register(new GraphSettingsPageModel(hudView.GraphSettingsPageView, graphPage.Groups, graphPage.GuideSettings));
+            var graphSaveManager = new GraphSaveManager(graphPage, nodeTemplateRepository);
+            var graphSlotPage = Register(new GraphSlotPageModel(hudView.GraphSlotPageView, graphSaveManager));
             var copyrightNoticesPage = Register(new CopyrightNoticesPageModel(hudView.CopyrightNoticesPageView));
             var memoryStatsRecorder = Register(new MemoryStatsRecorder());
 
@@ -91,7 +94,9 @@ namespace Rector
                 oscSettingsPage,
                 displaySettingsPage,
                 graphSettingsPage,
+                graphSlotPage,
                 copyrightNoticesPage,
+                graphPage,
                 hudView.SystemPageView));
             var hudModel = Register(new HudModel(hudView, graphPage, scenePage, menuPage, memoryStatsRecorder));
 
@@ -114,7 +119,8 @@ namespace Rector
                 nodeTemplateRepository,
                 vfxManager,
                 cameraManager,
-                bgSceneManager
+                bgSceneManager,
+                graphSaveManager
             )));
 
 #if !UNITY_EDITOR

--- a/Assets/Rector/Scripts/RectorLogger.cs
+++ b/Assets/Rector/Scripts/RectorLogger.cs
@@ -122,6 +122,47 @@ namespace Rector
             }
         }
 
+        public static void GraphSaved(int slot, int nodeCount, int edgeCount, int skippedNodes, int skippedEdges)
+        {
+            var skipped = skippedNodes > 0 || skippedEdges > 0
+                ? $" (skipped {skippedNodes} scene node(s), {skippedEdges} edge(s))"
+                : "";
+            LogInternal($"[GRAPH/SAVE] slot={slot} nodes={nodeCount} edges={edgeCount}{skipped}");
+        }
+
+        public static void GraphLoaded(int slot, int nodeCount, int edgeCount, int skippedNodes, int skippedEdges)
+        {
+            var skipped = skippedNodes > 0 || skippedEdges > 0
+                ? $" (dropped {skippedNodes} node(s), {skippedEdges} edge(s))"
+                : "";
+            LogInternal($"[GRAPH/LOAD] slot={slot} added {nodeCount} node(s), {edgeCount} edge(s){skipped}");
+        }
+
+        public static void GraphCleared(int nodeCount)
+        {
+            LogInternal($"[GRAPH/CLEAR] removed {nodeCount} node(s)");
+        }
+
+        public static void GraphSlotEmpty(int slot)
+        {
+            LogInternal($"[GRAPH/LOAD] slot={slot} is empty.");
+        }
+
+        public static void GraphLoadSkippedNode(string saveKey)
+        {
+            LogInternal($"[GRAPH/LOAD] unknown node template '{saveKey}'. Skipped.");
+        }
+
+        public static void GraphLoadSkippedValue(Node node, int slotIndex, string savedType)
+        {
+            LogInternal($"[GRAPH/LOAD] value dropped: {node.Name}[{slotIndex}] is not a {savedType} input");
+        }
+
+        public static void GraphLoadSkippedEdge(string reason)
+        {
+            LogInternal($"[GRAPH/LOAD] edge dropped: {reason}");
+        }
+
         public static void ActiveCamera(string cameraName)
         {
             LogInternal($"[CAMERA/CHANGE] name='{cameraName}'");

--- a/Assets/Rector/Scripts/UI/GraphPages/GraphPage.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/GraphPage.cs
@@ -463,6 +463,20 @@ namespace Rector.UI.GraphPages
             holdGuideModel.Visible.Value = false;
         }
 
+        /// <summary>
+        /// グラフを空にする。グラフのロードで作り直す前に呼ぶ。
+        /// </summary>
+        /// <remarks>
+        /// EnterNodeSelection を先に通すのは、選択・ターゲット・掴み(grabbedNode)の参照を
+        /// ノードが生きているうちに外すため。RemoveSelectedNode と同じ理由。
+        /// </remarks>
+        public void ClearGraph()
+        {
+            EnterNodeSelection(null);
+            Graph.ClearNodes();
+            Sort();
+        }
+
         public void RemoveSelectedNode()
         {
             if (SelectedNode is not { } node) return;

--- a/Assets/Rector/Scripts/UI/Graphs/NodeTemplate.cs
+++ b/Assets/Rector/Scripts/UI/Graphs/NodeTemplate.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using Rector.UI.Graphs.Nodes;
 
 namespace Rector.UI.Graphs
@@ -9,24 +8,54 @@ namespace Rector.UI.Graphs
         public readonly NodeTemplateId Id;
         public readonly NodeCategory Category;
         public readonly string Name;
+
+        /// <summary>
+        /// このテンプレートから作ったノードをグラフの保存に含めてよいか。
+        /// </summary>
+        /// <remarks>
+        /// Id とは別の概念。BGシーン由来のテンプレートも Id は持っているが、
+        /// シーンがアンロードされると登録ごと消えるので、いまは保存の対象外にしている。
+        /// </remarks>
+        public readonly bool IsSaveable;
+
         readonly Func<NodeId, NodeView> factory;
 
         public NodeView Create(NodeId id)
         {
-            return factory(id);
+            var view = factory(id);
+            // 生成経路はここ1本なので、どのノードも出自を持って生まれる
+            view.Node.TemplateId = Id;
+            view.Node.IsSaveable = IsSaveable;
+            return view;
         }
 
-        NodeTemplate(NodeTemplateId id, NodeCategory category, string name, Func<NodeId, NodeView> factory)
+        NodeTemplate(NodeTemplateId id, NodeCategory category, string name, bool isSaveable, Func<NodeId, NodeView> factory)
         {
             Id = id;
             Category = category;
             Name = name;
+            IsSaveable = isSaveable;
             this.factory = factory;
         }
 
-        public static NodeTemplate Create(NodeCategory category, string name, Func<NodeId, NodeView> factory)
-        {
-            return new NodeTemplate(NodeTemplateId.Generate(), category, name, factory);
-        }
+        /// <summary>コードで定義されたノードのテンプレート。ノードのクラス1つにつき1つ。</summary>
+        public static NodeTemplate Code<T>(NodeCategory category, string name, Func<NodeId, NodeView> factory)
+            where T : Node =>
+            new(NodeTemplateId.Code<T>(), category, name, true, factory);
+
+        /// <summary>NodeBehaviour が裏にいるノードのテンプレート。VFX とカメラ。</summary>
+        public static NodeTemplate Behaviour(Guid guid, NodeCategory category, string name, Func<NodeId, NodeView> factory) =>
+            new(NodeTemplateId.Behaviour(guid), category, name, true, factory);
+
+        /// <summary>
+        /// BGシーンがロードされている間だけ存在するテンプレート。保存の対象外になる。
+        /// </summary>
+        /// <remarks>
+        /// Id は Behaviour と同じ形で持てるが、シーンをアンロードすると登録が消えるため、
+        /// 別のシーンでグラフを復元するとスロット構成が分からずエッジも張れない。
+        /// 復元の設計は issue #81 から切り出した別 issue で扱う。
+        /// </remarks>
+        public static NodeTemplate SceneLocal(Guid guid, NodeCategory category, string name, Func<NodeId, NodeView> factory) =>
+            new(NodeTemplateId.Behaviour(guid), category, name, false, factory);
     }
 }

--- a/Assets/Rector/Scripts/UI/Graphs/NodeTemplateId.cs
+++ b/Assets/Rector/Scripts/UI/Graphs/NodeTemplateId.cs
@@ -1,47 +1,79 @@
 using System;
 
+#nullable enable
+
 namespace Rector.UI.Graphs
 {
+    public enum NodeTemplateKind
+    {
+        /// <summary>未設定。default(NodeTemplateId) を弾くために 0 を潰してある。</summary>
+        None = 0,
+
+        /// <summary>コードで定義されたノード。ノードのクラス1つにつきテンプレートが1つ。</summary>
+        Code,
+
+        /// <summary>NodeBehaviour が裏にいるノード。クラスは共通で、実体ごとにテンプレートがある。</summary>
+        Behaviour,
+    }
+
+    /// <summary>
+    /// ノードテンプレートの識別子。テンプレートの作られ方が2種類しかないので、その直和で表す。
+    /// </summary>
+    /// <remarks>
+    /// 起動を跨いで同じ値になるので、そのままグラフの保存ファイルに書ける。
+    ///
+    /// Code はノードのクラス名。VFX 名や GameObject 名のような表示用の文字列と違い、
+    /// 変えるにはコードを触ることになるので、うっかり保存ファイルを壊しにくい。
+    /// Behaviour は NodeBehaviour.guid。prefab やシーンのオブジェクトをリネームしても動かない。
+    /// </remarks>
     public readonly struct NodeTemplateId : IEquatable<NodeTemplateId>
     {
-        public readonly uint Value;
+        public readonly NodeTemplateKind Kind;
 
-        public NodeTemplateId(uint value)
+        /// <summary>Kind == Code のときだけ意味を持つ。ノードクラスの Type.Name。</summary>
+        public readonly string TypeName;
+
+        /// <summary>Kind == Behaviour のときだけ意味を持つ。</summary>
+        public readonly Guid Guid;
+
+        public bool IsValid => Kind != NodeTemplateKind.None;
+
+        NodeTemplateId(NodeTemplateKind kind, string typeName, Guid guid)
         {
-            Value = value;
+            Kind = kind;
+            TypeName = typeName;
+            Guid = guid;
         }
 
-        public bool Equals(NodeTemplateId other)
+        /// <remarks>
+        /// 型引数で受けるのは、クラスを消したり名前を変えたりしたときにコンパイルで気付くため。
+        /// 文字列で書くとビルドが通ってしまい、保存ファイルとの食い違いが実行時まで出てこない。
+        /// </remarks>
+        public static NodeTemplateId Code<T>() where T : Nodes.Node =>
+            new(NodeTemplateKind.Code, typeof(T).Name, Guid.Empty);
+
+        public static NodeTemplateId Code(string typeName) =>
+            new(NodeTemplateKind.Code, typeName, Guid.Empty);
+
+        public static NodeTemplateId Behaviour(Guid guid) =>
+            new(NodeTemplateKind.Behaviour, "", guid);
+
+        public bool Equals(NodeTemplateId other) =>
+            Kind == other.Kind && TypeName == other.TypeName && Guid.Equals(other.Guid);
+
+        public override bool Equals(object? obj) => obj is NodeTemplateId other && Equals(other);
+
+        public override int GetHashCode() => HashCode.Combine((int)Kind, TypeName, Guid);
+
+        public override string ToString() => Kind switch
         {
-            return Value == other.Value;
-        }
+            NodeTemplateKind.Code => $"code:{TypeName}",
+            NodeTemplateKind.Behaviour => $"behaviour:{Guid}",
+            _ => "none",
+        };
 
-        public override bool Equals(object obj)
-        {
-            return obj is NodeTemplateId other && Equals(other);
-        }
+        public static bool operator ==(NodeTemplateId left, NodeTemplateId right) => left.Equals(right);
 
-        public override int GetHashCode()
-        {
-            return (int)Value;
-        }
-
-        public static bool operator ==(NodeTemplateId left, NodeTemplateId right)
-        {
-            return left.Equals(right);
-        }
-
-        public static bool operator !=(NodeTemplateId left, NodeTemplateId right)
-        {
-            return !left.Equals(right);
-        }
-
-
-        static uint currentId;
-
-        public static NodeTemplateId Generate()
-        {
-            return new NodeTemplateId(currentId++);
-        }
+        public static bool operator !=(NodeTemplateId left, NodeTemplateId right) => !left.Equals(right);
     }
 }

--- a/Assets/Rector/Scripts/UI/Graphs/NodeTemplateRegisterer.cs
+++ b/Assets/Rector/Scripts/UI/Graphs/NodeTemplateRegisterer.cs
@@ -52,48 +52,48 @@ namespace Rector.UI.Graphs
         {
             foreach (var vfx in vfxManager.GetAllVfx())
             {
-                nodeTemplateRepository.Add(NodeTemplate.Create(VfxNode.GetCategory(), vfx.Name, id => CreateNodeView(new VfxNode(id, vfx))));
+                nodeTemplateRepository.Add(NodeTemplate.Behaviour(vfx.Guid, VfxNode.GetCategory(), vfx.Name, id => CreateNodeView(new VfxNode(id, vfx))));
             }
 
             foreach (var camera in cameraManager.GetCameraBehaviours())
             {
-                nodeTemplateRepository.Add(NodeTemplate.Create(CameraNode.GetCategory(), camera.Name, id => CreateNodeView(new CameraNode(id, camera))));
+                nodeTemplateRepository.Add(NodeTemplate.Behaviour(camera.Guid, CameraNode.GetCategory(), camera.Name, id => CreateNodeView(new CameraNode(id, camera))));
             }
 
-            nodeTemplateRepository.Add(NodeTemplate.Create(CameraBlendNode.GetCategory(), CameraBlendNode.NodeName, id => CreateNodeView(new CameraBlendNode(id, cameraManager))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<CameraBlendNode>(CameraBlendNode.GetCategory(), CameraBlendNode.NodeName, id => CreateNodeView(new CameraBlendNode(id, cameraManager))));
 
-            nodeTemplateRepository.Add(NodeTemplate.Create(AudioThresholdNode.GetCategory(), AudioThresholdNode.NodeName, id => CreateNodeView(new AudioThresholdNode(id, audioMixerModel))));
-            nodeTemplateRepository.Add(NodeTemplate.Create(LevelNode.GetCategory(), LevelNode.NodeName, id => CreateNodeView(new LevelNode(id, audioMixerModel))));
-            nodeTemplateRepository.Add(NodeTemplate.Create(BeatNode.GetCategory(), BeatNode.NodeName, id => CreateNodeView(new BeatNode(id, beatModel))));
-            nodeTemplateRepository.Add(NodeTemplate.Create(MidiNoteNode.GetCategory(), MidiNoteNode.NodeName, id => CreateNodeView(new MidiNoteNode(id, midiModel))));
-            nodeTemplateRepository.Add(NodeTemplate.Create(MidiCcNode.GetCategory(), MidiCcNode.NodeName, id => CreateNodeView(new MidiCcNode(id, midiModel))));
-            nodeTemplateRepository.Add(NodeTemplate.Create(OscNode.GetCategory(), OscNode.NodeName, id => CreateNodeView(new OscNode(id, oscModel))));
-            nodeTemplateRepository.Add(NodeTemplate.Create(UpdateNode.GetCategory(), UpdateNode.NodeName, id => CreateNodeView(new UpdateNode(id))));
-            nodeTemplateRepository.Add(NodeTemplate.Create(TimeNode.GetCategory(), TimeNode.NodeName, id => CreateNodeView(new TimeNode(id))));
-            nodeTemplateRepository.Add(NodeTemplate.Create(ButtonNode.GetCategory(), ButtonNode.NodeName, id => CreateNodeView(new ButtonNode(id))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<AudioThresholdNode>(AudioThresholdNode.GetCategory(), AudioThresholdNode.NodeName, id => CreateNodeView(new AudioThresholdNode(id, audioMixerModel))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<LevelNode>(LevelNode.GetCategory(), LevelNode.NodeName, id => CreateNodeView(new LevelNode(id, audioMixerModel))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<BeatNode>(BeatNode.GetCategory(), BeatNode.NodeName, id => CreateNodeView(new BeatNode(id, beatModel))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<MidiNoteNode>(MidiNoteNode.GetCategory(), MidiNoteNode.NodeName, id => CreateNodeView(new MidiNoteNode(id, midiModel))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<MidiCcNode>(MidiCcNode.GetCategory(), MidiCcNode.NodeName, id => CreateNodeView(new MidiCcNode(id, midiModel))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<OscNode>(OscNode.GetCategory(), OscNode.NodeName, id => CreateNodeView(new OscNode(id, oscModel))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<UpdateNode>(UpdateNode.GetCategory(), UpdateNode.NodeName, id => CreateNodeView(new UpdateNode(id))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<TimeNode>(TimeNode.GetCategory(), TimeNode.NodeName, id => CreateNodeView(new TimeNode(id))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<ButtonNode>(ButtonNode.GetCategory(), ButtonNode.NodeName, id => CreateNodeView(new ButtonNode(id))));
 
-            nodeTemplateRepository.Add(NodeTemplate.Create(Switch2Node.GetCategory(), Switch2Node.NodeName, id => CreateNodeView(new Switch2Node(id))));
-            nodeTemplateRepository.Add(NodeTemplate.Create(Switch4Node.GetCategory(), Switch4Node.NodeName, id => CreateNodeView(new Switch4Node(id))));
-            nodeTemplateRepository.Add(NodeTemplate.Create(Switch16Node.GetCategory(), Switch16Node.NodeName, id => CreateNodeView(new Switch16Node(id))));
-            nodeTemplateRepository.Add(NodeTemplate.Create(Switch4By4Node.GetCategory(), Switch4By4Node.NodeName, id => CreateNodeView(new Switch4By4Node(id))));
-            nodeTemplateRepository.Add(NodeTemplate.Create(AndNode.GetCategory(), AndNode.NodeName, id => CreateNodeView(new AndNode(id))));
-            nodeTemplateRepository.Add(NodeTemplate.Create(OrNode.GetCategory(), OrNode.NodeName, id => CreateNodeView(new OrNode(id))));
-            nodeTemplateRepository.Add(NodeTemplate.Create(GateNode.GetCategory(), GateNode.NodeName, id => CreateNodeView(new GateNode(id))));
-            nodeTemplateRepository.Add(NodeTemplate.Create(NegateNode.GetCategory(), NegateNode.NodeName, id => CreateNodeView(new NegateNode(id))));
-            nodeTemplateRepository.Add(NodeTemplate.Create(WithNode.GetCategory(), WithNode.NodeName, id => CreateNodeView(new WithNode(id))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<Switch2Node>(Switch2Node.GetCategory(), Switch2Node.NodeName, id => CreateNodeView(new Switch2Node(id))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<Switch4Node>(Switch4Node.GetCategory(), Switch4Node.NodeName, id => CreateNodeView(new Switch4Node(id))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<Switch16Node>(Switch16Node.GetCategory(), Switch16Node.NodeName, id => CreateNodeView(new Switch16Node(id))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<Switch4By4Node>(Switch4By4Node.GetCategory(), Switch4By4Node.NodeName, id => CreateNodeView(new Switch4By4Node(id))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<AndNode>(AndNode.GetCategory(), AndNode.NodeName, id => CreateNodeView(new AndNode(id))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<OrNode>(OrNode.GetCategory(), OrNode.NodeName, id => CreateNodeView(new OrNode(id))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<GateNode>(GateNode.GetCategory(), GateNode.NodeName, id => CreateNodeView(new GateNode(id))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<NegateNode>(NegateNode.GetCategory(), NegateNode.NodeName, id => CreateNodeView(new NegateNode(id))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<WithNode>(WithNode.GetCategory(), WithNode.NodeName, id => CreateNodeView(new WithNode(id))));
 
-            nodeTemplateRepository.Add(NodeTemplate.Create(MadNode.GetCategory(), MadNode.NodeName, id => CreateNodeView(new MadNode(id))));
-            nodeTemplateRepository.Add(NodeTemplate.Create(FloatNode.GetCategory(), FloatNode.NodeName, id => CreateNodeView(new FloatNode(id))));
-            nodeTemplateRepository.Add(NodeTemplate.Create(Vector3Node.GetCategory(), Vector3Node.NodeName, id => CreateNodeView(new Vector3Node(id))));
-            nodeTemplateRepository.Add(NodeTemplate.Create(SinNode.GetCategory(), SinNode.NodeName, id => CreateNodeView(new SinNode(id))));
-            nodeTemplateRepository.Add(NodeTemplate.Create(CosNode.GetCategory(), CosNode.NodeName, id => CreateNodeView(new CosNode(id))));
-            nodeTemplateRepository.Add(NodeTemplate.Create(MinNode.GetCategory(), MinNode.NodeName, id => CreateNodeView(new MinNode(id))));
-            nodeTemplateRepository.Add(NodeTemplate.Create(MaxNode.GetCategory(), MaxNode.NodeName, id => CreateNodeView(new MaxNode(id))));
-            nodeTemplateRepository.Add(NodeTemplate.Create(FractNode.GetCategory(), FractNode.NodeName, id => CreateNodeView(new FractNode(id))));
-            nodeTemplateRepository.Add(NodeTemplate.Create(StepNode.GetCategory(), StepNode.NodeName, id => CreateNodeView(new StepNode(id))));
-            nodeTemplateRepository.Add(NodeTemplate.Create(CircleNode.GetCategory(), CircleNode.NodeName, id => CreateNodeView(new CircleNode(id))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<MadNode>(MadNode.GetCategory(), MadNode.NodeName, id => CreateNodeView(new MadNode(id))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<FloatNode>(FloatNode.GetCategory(), FloatNode.NodeName, id => CreateNodeView(new FloatNode(id))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<Vector3Node>(Vector3Node.GetCategory(), Vector3Node.NodeName, id => CreateNodeView(new Vector3Node(id))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<SinNode>(SinNode.GetCategory(), SinNode.NodeName, id => CreateNodeView(new SinNode(id))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<CosNode>(CosNode.GetCategory(), CosNode.NodeName, id => CreateNodeView(new CosNode(id))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<MinNode>(MinNode.GetCategory(), MinNode.NodeName, id => CreateNodeView(new MinNode(id))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<MaxNode>(MaxNode.GetCategory(), MaxNode.NodeName, id => CreateNodeView(new MaxNode(id))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<FractNode>(FractNode.GetCategory(), FractNode.NodeName, id => CreateNodeView(new FractNode(id))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<StepNode>(StepNode.GetCategory(), StepNode.NodeName, id => CreateNodeView(new StepNode(id))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<CircleNode>(CircleNode.GetCategory(), CircleNode.NodeName, id => CreateNodeView(new CircleNode(id))));
 
-            nodeTemplateRepository.Add(NodeTemplate.Create(HudStyleNode.GetCategory(), HudStyleNode.NodeName, id => CreateNodeView(new HudStyleNode(id, hudModel))));
+            nodeTemplateRepository.Add(NodeTemplate.Code<HudStyleNode>(HudStyleNode.GetCategory(), HudStyleNode.NodeName, id => CreateNodeView(new HudStyleNode(id, hudModel))));
 
             /* Add your custom node here  */
         }

--- a/Assets/Rector/Scripts/UI/Graphs/NodeTemplateRepository.cs
+++ b/Assets/Rector/Scripts/UI/Graphs/NodeTemplateRepository.cs
@@ -1,33 +1,43 @@
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace Rector.UI.Graphs
 {
     public sealed class NodeTemplateRepository
     {
-        readonly Dictionary<NodeTemplateId, NodeTemplate> factories = new();
+        readonly Dictionary<NodeTemplateId, NodeTemplate> templates = new();
         readonly Dictionary<NodeCategory, List<NodeTemplate>> categoryNodeSet = new();
         public IReadOnlyDictionary<NodeCategory, List<NodeTemplate>> CategoryNodeSet => categoryNodeSet;
 
-        public void Add(NodeTemplate factory)
+        public void Add(NodeTemplate template)
         {
-            factories.Add(factory.Id, factory);
-            if (!categoryNodeSet.TryGetValue(factory.Category, out var list))
+            // Id は起動を跨いで安定なので、衝突は登録側の間違い(同じクラスを2回、guid の重複)。
+            // 作成メニューからは消さず、グラフのロードで取り違える可能性だけ警告する。
+            if (!templates.TryAdd(template.Id, template))
             {
-                list = new List<NodeTemplate>();
-                categoryNodeSet.Add(factory.Category, list);
+                Debug.LogWarning($"Duplicate node template id '{template.Id}' for '{template.Name}'. Saved graphs may restore the wrong node.");
+                return;
             }
 
-            list.Add(factory);
+            if (!categoryNodeSet.TryGetValue(template.Category, out var list))
+            {
+                list = new List<NodeTemplate>();
+                categoryNodeSet.Add(template.Category, list);
+            }
+
+            list.Add(template);
         }
+
+        public bool TryGet(NodeTemplateId id, out NodeTemplate template) => templates.TryGetValue(id, out template);
 
         public IEnumerable<NodeTemplate> GetAll()
         {
-            return factories.Values;
+            return templates.Values;
         }
 
         public bool Remove(NodeTemplateId id)
         {
-            if (factories.Remove(id, out var nodeTemplate))
+            if (templates.Remove(id, out var nodeTemplate))
             {
                 if (categoryNodeSet.TryGetValue(nodeTemplate.Category, out var list))
                 {

--- a/Assets/Rector/Scripts/UI/Graphs/Nodes/Node.cs
+++ b/Assets/Rector/Scripts/UI/Graphs/Nodes/Node.cs
@@ -7,6 +7,14 @@ namespace Rector.UI.Graphs.Nodes
     {
         public NodeId Id { get; }
         public string Name { get; }
+
+        /// <summary>このノードを生んだ NodeTemplate の Id。</summary>
+        /// <remarks>NodeTemplate.Create(NodeId) が刻むので、ノード側から設定することはない。</remarks>
+        public NodeTemplateId TemplateId { get; internal set; }
+
+        /// <summary>グラフの保存に含めてよいか。テンプレートから引き継ぐ。</summary>
+        public bool IsSaveable { get; internal set; }
+
         public abstract NodeCategory Category { get; }
         public abstract InputSlot[] InputSlots { get; }
         public abstract OutputSlot[] OutputSlots { get; }

--- a/Assets/Rector/Scripts/UI/Graphs/Serialization.meta
+++ b/Assets/Rector/Scripts/UI/Graphs/Serialization.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1fb4bf4f6afe44a34a2903db16ad59dd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Rector/Scripts/UI/Graphs/Serialization/GraphSaveData.cs
+++ b/Assets/Rector/Scripts/UI/Graphs/Serialization/GraphSaveData.cs
@@ -1,0 +1,133 @@
+using System;
+using UnityEngine;
+
+namespace Rector.UI.Graphs.Serialization
+{
+    /// <summary>
+    /// 保存されたグラフ。JsonUtility で読み書きするので、多相も Dictionary も使わず
+    /// 値の型ごとに配列を分けた平たい形にしている。
+    /// </summary>
+    /// <remarks>
+    /// これは永続化データの形なので、後方互換を壊す変更をするなら version を上げること。
+    /// スロットは index で指す。ノードのスロット構成を変えると古いファイルの index はズレるが、
+    /// エッジには型を持たせてあるので、ズレたエッジは別のスロットに繋がらず落ちる。
+    /// ノードの識別子は nodes 配列の index。NodeId は起動ごとの採番なので保存しない。
+    /// </remarks>
+    [Serializable]
+    public sealed class GraphSaveData
+    {
+        public const int CurrentVersion = 1;
+
+        /// <summary>
+        /// 形式の版数。既定値を持たせないのは、version の無い JSON を v1 と誤認しないため。
+        /// </summary>
+        public int version;
+
+        /// <summary>保存日時。一覧に出すだけで、復元には使わない。</summary>
+        public string savedAt = "";
+
+        public NodeSaveData[] nodes = Array.Empty<NodeSaveData>();
+        public EdgeSaveData[] edges = Array.Empty<EdgeSaveData>();
+
+        public bool IsSupportedVersion => version == CurrentVersion;
+    }
+
+    /// <summary>NodeTemplateId と保存用フィールドの相互変換。</summary>
+    public static class NodeTemplateIdSaveData
+    {
+        public static void Write(NodeTemplateId id, NodeSaveData data)
+        {
+            data.templateKind = id.Kind.ToString();
+            data.nodeType = id.Kind == NodeTemplateKind.Code ? id.TypeName : "";
+            data.behaviourGuid = id.Kind == NodeTemplateKind.Behaviour ? id.Guid.ToString() : "";
+        }
+
+        /// <summary>読めなければ IsValid が false の値を返す。呼び出し側はそのノードを捨てる。</summary>
+        public static NodeTemplateId Read(NodeSaveData data)
+        {
+            if (!Enum.TryParse<NodeTemplateKind>(data.templateKind, out var kind)) return default;
+
+            switch (kind)
+            {
+                case NodeTemplateKind.Code:
+                    return string.IsNullOrEmpty(data.nodeType) ? default : NodeTemplateId.Code(data.nodeType);
+                case NodeTemplateKind.Behaviour:
+                    return Guid.TryParse(data.behaviourGuid, out var guid) ? NodeTemplateId.Behaviour(guid) : default;
+                default:
+                    return default;
+            }
+        }
+    }
+
+    /// <remarks>
+    /// 配列の初期化子は必須。JsonUtility は JSON にキーが無いフィールドを初期値のままにするので、
+    /// 初期化子を消すと欠けたキーが null になり、復元側の foreach が落ちる。
+    /// </remarks>
+    [Serializable]
+    public sealed class NodeSaveData
+    {
+        // --- NodeTemplateId。直和なので、templateKind が示すフィールドだけが埋まる ---
+
+        /// <summary>NodeTemplateKind の名前。"Code" または "Behaviour"。</summary>
+        public string templateKind = "";
+
+        /// <summary>templateKind == Code のとき、ノードクラスの Type.Name。</summary>
+        public string nodeType = "";
+
+        /// <summary>templateKind == Behaviour のとき、NodeBehaviour.guid。</summary>
+        public string behaviourGuid = "";
+
+        // 値の型はどの配列に入っているかで決まる。復元時は同じ型の入力スロットにしか入らない。
+        public FloatSlotValue[] floats = Array.Empty<FloatSlotValue>();
+        public IntSlotValue[] ints = Array.Empty<IntSlotValue>();
+        public BoolSlotValue[] bools = Array.Empty<BoolSlotValue>();
+        public Vector3SlotValue[] vector3s = Array.Empty<Vector3SlotValue>();
+    }
+
+    [Serializable]
+    public sealed class FloatSlotValue
+    {
+        public int index;
+        public float value;
+    }
+
+    [Serializable]
+    public sealed class IntSlotValue
+    {
+        public int index;
+        public int value;
+    }
+
+    [Serializable]
+    public sealed class BoolSlotValue
+    {
+        public int index;
+        public bool value;
+    }
+
+    [Serializable]
+    public sealed class Vector3SlotValue
+    {
+        public int index;
+        public Vector3 value;
+    }
+
+    /// <remarks>
+    /// fromType / toType は SlotValueType の名前。復元時に今のスロットの型と突き合わせ、
+    /// 食い違えばそのエッジを落とす。これが無いと、スロットがズレたときに
+    /// 型だけ合う別のスロットへ黙って繋がってしまう。
+    /// </remarks>
+    [Serializable]
+    public sealed class EdgeSaveData
+    {
+        /// <summary>GraphSaveData.nodes の index。</summary>
+        public int fromNode;
+
+        public int fromSlot;
+        public string fromType = "";
+
+        public int toNode;
+        public int toSlot;
+        public string toType = "";
+    }
+}

--- a/Assets/Rector/Scripts/UI/Graphs/Serialization/GraphSaveData.cs.meta
+++ b/Assets/Rector/Scripts/UI/Graphs/Serialization/GraphSaveData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4c3bfc2437375452990d8860aa166bc2

--- a/Assets/Rector/Scripts/UI/Graphs/Serialization/GraphSaveManager.cs
+++ b/Assets/Rector/Scripts/UI/Graphs/Serialization/GraphSaveManager.cs
@@ -1,0 +1,56 @@
+using Rector.UI.GraphPages;
+
+#nullable enable
+
+namespace Rector.UI.Graphs.Serialization
+{
+    /// <summary>
+    /// グラフのスロットへの保存と読み込み。HUD と CLI の共通の入り口。
+    /// </summary>
+    public sealed class GraphSaveManager
+    {
+        readonly GraphSerializer serializer;
+        readonly GraphSlotRepository repository;
+
+        public GraphSaveManager(GraphPage graphPage, NodeTemplateRepository nodeTemplateRepository)
+            : this(new GraphSerializer(graphPage, nodeTemplateRepository), new GraphSlotRepository())
+        {
+        }
+
+        public GraphSaveManager(GraphSerializer serializer, GraphSlotRepository repository)
+        {
+            this.serializer = serializer;
+            this.repository = repository;
+        }
+
+        public GraphSlotInfo[] GetAllSlotInfo() => repository.GetAllInfo();
+
+        public GraphSlotInfo GetSlotInfo(int slot) => repository.GetInfo(slot);
+
+        public bool Save(int slot, out GraphSaveResult result)
+        {
+            var data = serializer.Capture(out result);
+            if (!repository.Write(slot, data)) return false;
+
+            RectorLogger.GraphSaved(slot, result.NodeCount, result.EdgeCount, result.SkippedNodeCount, result.SkippedEdgeCount);
+            return true;
+        }
+
+        /// <summary>空のスロットや壊れたファイルでは false を返し、グラフには触らない。</summary>
+        public bool Load(int slot, out GraphLoadResult result)
+        {
+            result = default;
+
+            var data = repository.Read(slot);
+            if (data == null)
+            {
+                RectorLogger.GraphSlotEmpty(slot);
+                return false;
+            }
+
+            result = serializer.Restore(data);
+            RectorLogger.GraphLoaded(slot, result.NodeCount, result.EdgeCount, result.SkippedNodeCount, result.SkippedEdgeCount);
+            return true;
+        }
+    }
+}

--- a/Assets/Rector/Scripts/UI/Graphs/Serialization/GraphSaveManager.cs.meta
+++ b/Assets/Rector/Scripts/UI/Graphs/Serialization/GraphSaveManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 71f3c96b98b604765b7698c3e3816752

--- a/Assets/Rector/Scripts/UI/Graphs/Serialization/GraphSerializer.cs
+++ b/Assets/Rector/Scripts/UI/Graphs/Serialization/GraphSerializer.cs
@@ -1,0 +1,319 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Rector.UI.GraphPages;
+using Rector.UI.Graphs.Nodes;
+using Rector.UI.Graphs.Slots;
+using Rector.UI.LayeredGraphDrawing;
+using UnityEngine;
+
+#nullable enable
+
+namespace Rector.UI.Graphs.Serialization
+{
+    /// <summary>グラフのロード結果。何が復元できて何が落ちたかを呼び出し側へ返す。</summary>
+    public readonly struct GraphLoadResult
+    {
+        public readonly int NodeCount;
+        public readonly int EdgeCount;
+        public readonly int SkippedNodeCount;
+        public readonly int SkippedEdgeCount;
+
+        public GraphLoadResult(int nodeCount, int edgeCount, int skippedNodeCount, int skippedEdgeCount)
+        {
+            NodeCount = nodeCount;
+            EdgeCount = edgeCount;
+            SkippedNodeCount = skippedNodeCount;
+            SkippedEdgeCount = skippedEdgeCount;
+        }
+    }
+
+    /// <summary>グラフの保存結果。</summary>
+    public readonly struct GraphSaveResult
+    {
+        public readonly int NodeCount;
+        public readonly int EdgeCount;
+        public readonly int SkippedNodeCount;
+        public readonly int SkippedEdgeCount;
+
+        public GraphSaveResult(int nodeCount, int edgeCount, int skippedNodeCount, int skippedEdgeCount)
+        {
+            NodeCount = nodeCount;
+            EdgeCount = edgeCount;
+            SkippedNodeCount = skippedNodeCount;
+            SkippedEdgeCount = skippedEdgeCount;
+        }
+    }
+
+    /// <summary>
+    /// グラフと GraphSaveData の間の変換。
+    /// </summary>
+    public sealed class GraphSerializer
+    {
+        readonly GraphPage graphPage;
+        readonly NodeTemplateRepository nodeTemplateRepository;
+
+        public GraphSerializer(GraphPage graphPage, NodeTemplateRepository nodeTemplateRepository)
+        {
+            this.graphPage = graphPage;
+            this.nodeTemplateRepository = nodeTemplateRepository;
+        }
+
+        // ---------------------------------------------------------------- 保存
+
+        public GraphSaveData Capture(out GraphSaveResult result)
+        {
+            var graph = graphPage.Graph;
+
+            // 保存できないノード(BGシーン由来)はエッジの端点にもなれないので、
+            // 先に「保存するノード」を確定してから index を振る。
+            var indexOf = new Dictionary<NodeId, int>();
+            var nodes = new List<NodeSaveData>();
+            var skippedNodeCount = 0;
+
+            foreach (var layeredNode in graph.Nodes)
+            {
+                var node = layeredNode.NodeView.Node;
+                if (!node.IsSaveable)
+                {
+                    skippedNodeCount++;
+                    continue;
+                }
+
+                indexOf.Add(node.Id, nodes.Count);
+                nodes.Add(CaptureNode(node));
+            }
+
+            var edges = new List<EdgeSaveData>();
+            var skippedEdgeCount = 0;
+
+            foreach (var id in graph.Edges.Keys)
+            {
+                if (!indexOf.TryGetValue(id.OutputNodeId, out var from) ||
+                    !indexOf.TryGetValue(id.InputNodeId, out var to))
+                {
+                    skippedEdgeCount++;
+                    continue;
+                }
+
+                edges.Add(new EdgeSaveData
+                {
+                    fromNode = from,
+                    fromSlot = id.OutputSlotIndex,
+                    fromType = OutputTypeName(graph, id.OutputNodeId, id.OutputSlotIndex),
+                    toNode = to,
+                    toSlot = id.InputSlotIndex,
+                    toType = InputTypeName(graph, id.InputNodeId, id.InputSlotIndex),
+                });
+            }
+
+            result = new GraphSaveResult(nodes.Count, edges.Count, skippedNodeCount, skippedEdgeCount);
+
+            return new GraphSaveData
+            {
+                version = GraphSaveData.CurrentVersion,
+                savedAt = DateTimeOffset.Now.ToString("o", CultureInfo.InvariantCulture),
+                nodes = nodes.ToArray(),
+                edges = edges.ToArray(),
+            };
+        }
+
+        static NodeSaveData CaptureNode(Node node)
+        {
+            var floats = new List<FloatSlotValue>();
+            var ints = new List<IntSlotValue>();
+            var bools = new List<BoolSlotValue>();
+            var vector3s = new List<Vector3SlotValue>();
+
+            foreach (var slot in node.InputSlots)
+            {
+                // 繋がっているスロットはロード後にエッジが値を流し込むので保存しない。
+                // CallbackInputSlot(イベント) と Transform 入力はそもそも値を持たない/持ち出せない。
+                if (slot.ConnectedCount > 0) continue;
+
+                switch (slot)
+                {
+                    case ReactivePropertyInputSlot<float> s:
+                        floats.Add(new FloatSlotValue { index = s.Index, value = s.Property.Value });
+                        break;
+                    case ReactivePropertyInputSlot<int> s:
+                        ints.Add(new IntSlotValue { index = s.Index, value = s.Property.Value });
+                        break;
+                    case ReactivePropertyInputSlot<bool> s:
+                        bools.Add(new BoolSlotValue { index = s.Index, value = s.Property.Value });
+                        break;
+                    case ReactivePropertyInputSlot<Vector3> s:
+                        vector3s.Add(new Vector3SlotValue { index = s.Index, value = s.Property.Value });
+                        break;
+                }
+            }
+
+            var data = new NodeSaveData
+            {
+                floats = floats.ToArray(),
+                ints = ints.ToArray(),
+                bools = bools.ToArray(),
+                vector3s = vector3s.ToArray(),
+            };
+            NodeTemplateIdSaveData.Write(node.TemplateId, data);
+            return data;
+        }
+
+        static string OutputTypeName(LayeredGraph graph, NodeId nodeId, int index) =>
+            graph.TryGetNode(nodeId, out var n) ? TypeNameAt(n.NodeView.Node.OutputSlots, index) : "";
+
+        static string InputTypeName(LayeredGraph graph, NodeId nodeId, int index) =>
+            graph.TryGetNode(nodeId, out var n) ? TypeNameAt(n.NodeView.Node.InputSlots, index) : "";
+
+        static string TypeNameAt<T>(T[] slots, int index) where T : ISlot =>
+            index >= 0 && index < slots.Length ? slots[index].Type.ToString() : "";
+
+        // -------------------------------------------------------------- ロード
+
+        /// <summary>
+        /// 保存データのノードとエッジを今のグラフへ足す。復元できないものは飛ばして残りを組む。
+        /// </summary>
+        /// <remarks>
+        /// 既存のノードには触らない(非破壊)。ノードIDは採番し直し、エッジは保存ファイル内の
+        /// index から引くので、読み込んだノード同士しか繋がらない。既存グラフと混線することはない。
+        /// 差し込み先のグループは AddNode が決める(選択中のノードと同じグループ)ので、
+        /// メニューを開く前に選んでおいたノードが行き先になる。
+        /// 丸ごと入れ替えたいときは、呼ぶ側が先に GraphPage.ClearGraph を通すこと。
+        /// </remarks>
+        public GraphLoadResult Restore(GraphSaveData data)
+        {
+            var nodeIds = new NodeId?[data.nodes.Length];
+            var skippedNodeCount = 0;
+            NodeId? firstNodeId = null;
+
+            for (var i = 0; i < data.nodes.Length; i++)
+            {
+                var saved = data.nodes[i];
+                var templateId = NodeTemplateIdSaveData.Read(saved);
+                if (!templateId.IsValid || !nodeTemplateRepository.TryGet(templateId, out var template))
+                {
+                    RectorLogger.GraphLoadSkippedNode(templateId.IsValid ? templateId.ToString() : $"{saved.templateKind}/{saved.nodeType}{saved.behaviourGuid}");
+                    skippedNodeCount++;
+                    continue;
+                }
+
+                var nodeView = template.Create(NodeId.Generate());
+                graphPage.AddNode(nodeView);
+                nodeIds[i] = nodeView.Node.Id;
+                firstNodeId ??= nodeView.Node.Id;
+
+                // エッジより先に値を入れる。接続すると上流の現在値が流れ込むので、
+                // 順序を逆にすると復元した値がいったん上書きされる過渡状態が生まれる。
+                RestoreValues(nodeView.Node, saved);
+            }
+
+            var edgeCount = 0;
+            var skippedEdgeCount = 0;
+
+            foreach (var edge in data.edges)
+            {
+                if (TryConnect(edge, nodeIds)) edgeCount++;
+                else skippedEdgeCount++;
+            }
+
+            SelectFirstLoadedNode(firstNodeId);
+
+            graphPage.Sort();
+            return new GraphLoadResult(data.nodes.Length - skippedNodeCount, edgeCount, skippedNodeCount, skippedEdgeCount);
+        }
+
+        /// <remarks>
+        /// index の位置に同じ型の入力スロットが無ければ、その値は捨てる。
+        /// ノードのスロット構成が変わった古いファイルで、関係ないスロットへ値を入れないため。
+        /// </remarks>
+        static void RestoreValues(Node node, NodeSaveData saved)
+        {
+            foreach (var v in saved.floats)
+            {
+                if (ValueSlotAt<float>(node, v.index) is { } slot) slot.Property.Value = v.value;
+                else RectorLogger.GraphLoadSkippedValue(node, v.index, "Float");
+            }
+
+            foreach (var v in saved.ints)
+            {
+                if (ValueSlotAt<int>(node, v.index) is { } slot) slot.Property.Value = v.value;
+                else RectorLogger.GraphLoadSkippedValue(node, v.index, "Int");
+            }
+
+            foreach (var v in saved.bools)
+            {
+                if (ValueSlotAt<bool>(node, v.index) is { } slot) slot.Property.Value = v.value;
+                else RectorLogger.GraphLoadSkippedValue(node, v.index, "Boolean");
+            }
+
+            foreach (var v in saved.vector3s)
+            {
+                if (ValueSlotAt<Vector3>(node, v.index) is { } slot) slot.Property.Value = v.value;
+                else RectorLogger.GraphLoadSkippedValue(node, v.index, "Vector3");
+            }
+        }
+
+        static ReactivePropertyInputSlot<T>? ValueSlotAt<T>(Node node, int index) =>
+            SlotAt(node.InputSlots, index) as ReactivePropertyInputSlot<T>;
+
+        static T? SlotAt<T>(T[] slots, int index) where T : class, ISlot =>
+            index >= 0 && index < slots.Length ? slots[index] : null;
+
+        /// <summary>
+        /// 差し込んだ先頭のノードへカーソルを移す。メニューを閉じたら、そのまま繋ぎにいける。
+        /// </summary>
+        /// <remarks>
+        /// 全部足し終えてから呼ぶこと。途中で選択を動かすと、以降の AddNode の
+        /// 行き先グループが変わってしまう。
+        /// </remarks>
+        void SelectFirstLoadedNode(NodeId? firstNodeId)
+        {
+            if (firstNodeId is not { } id) return;
+            if (!graphPage.Graph.TryGetNode(id, out var first)) return;
+
+            graphPage.EnterNodeSelection(first);
+        }
+
+        bool TryConnect(EdgeSaveData edge, NodeId?[] nodeIds)
+        {
+            if (!TryGetNode(edge.fromNode, nodeIds, out var from) ||
+                !TryGetNode(edge.toNode, nodeIds, out var to))
+            {
+                return false;
+            }
+
+            var output = SlotAt(from.OutputSlots, edge.fromSlot);
+            var input = SlotAt(to.InputSlots, edge.toSlot);
+            if (output == null || input == null)
+            {
+                RectorLogger.GraphLoadSkippedEdge($"slot index out of range ({from.Name}[{edge.fromSlot}] -> {to.Name}[{edge.toSlot}])");
+                return false;
+            }
+
+            // 型が食い違うなら、スロットの並びが変わったファイル。別のスロットへ繋がないよう落とす
+            if (output.Type.ToString() != edge.fromType || input.Type.ToString() != edge.toType)
+            {
+                RectorLogger.GraphLoadSkippedEdge(
+                    $"slot type changed ({from.Name}[{edge.fromSlot}] {edge.fromType}->{output.Type}, {to.Name}[{edge.toSlot}] {edge.toType}->{input.Type})");
+                return false;
+            }
+
+            var result = graphPage.TryConnectSlots(output, input);
+            if (result == ConnectResult.Connected) return true;
+
+            RectorLogger.GraphLoadSkippedEdge($"{result} ({from.Name}.{output.Name} -> {to.Name}.{input.Name})");
+            return false;
+        }
+
+        bool TryGetNode(int savedIndex, NodeId?[] nodeIds, out Node node)
+        {
+            node = null!;
+            if (savedIndex < 0 || savedIndex >= nodeIds.Length) return false;
+            if (nodeIds[savedIndex] is not { } id) return false;
+            if (!graphPage.Graph.TryGetNode(id, out var layeredNode)) return false;
+
+            node = layeredNode.NodeView.Node;
+            return true;
+        }
+    }
+}

--- a/Assets/Rector/Scripts/UI/Graphs/Serialization/GraphSerializer.cs.meta
+++ b/Assets/Rector/Scripts/UI/Graphs/Serialization/GraphSerializer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 96db02229991045829618a7cdbad6236

--- a/Assets/Rector/Scripts/UI/Graphs/Serialization/GraphSlotRepository.cs
+++ b/Assets/Rector/Scripts/UI/Graphs/Serialization/GraphSlotRepository.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Globalization;
+using System.IO;
+using UnityEngine;
+
+#nullable enable
+
+namespace Rector.UI.Graphs.Serialization
+{
+    /// <summary>一覧に出すためのスロットの中身。</summary>
+    public readonly struct GraphSlotInfo
+    {
+        /// <summary>1 始まり。HUD の表示と揃える。</summary>
+        public readonly int Number;
+
+        public readonly bool IsEmpty;
+        public readonly int NodeCount;
+        public readonly int EdgeCount;
+
+        /// <summary>保存日時の表示用文字列。空のスロットでは空。</summary>
+        public readonly string SavedAt;
+
+        public GraphSlotInfo(int number, bool isEmpty, int nodeCount, int edgeCount, string savedAt)
+        {
+            Number = number;
+            IsEmpty = isEmpty;
+            NodeCount = nodeCount;
+            EdgeCount = edgeCount;
+            SavedAt = savedAt;
+        }
+
+        public static GraphSlotInfo Empty(int number) => new(number, true, 0, 0, "");
+    }
+
+    /// <summary>
+    /// グラフの保存ファイルを固定スロットとして扱う。
+    /// </summary>
+    /// <remarks>
+    /// HUD は全てゲームパッド操作でテキスト入力の口が無いため、名前を付けさせず番号で持つ。
+    /// ファイルは数 KB なので同期 IO で読み書きする。
+    /// </remarks>
+    public sealed class GraphSlotRepository
+    {
+        public const int SlotCount = 8;
+
+        readonly string directory;
+
+        public GraphSlotRepository() : this(Path.Combine(Application.persistentDataPath, "graphs"))
+        {
+        }
+
+        public GraphSlotRepository(string directory)
+        {
+            this.directory = directory;
+        }
+
+        public static bool IsValidSlot(int number) => number >= 1 && number <= SlotCount;
+
+        string PathOf(int number) => Path.Combine(directory, $"slot{number}.json");
+
+        public GraphSlotInfo GetInfo(int number)
+        {
+            if (!IsValidSlot(number)) return GraphSlotInfo.Empty(number);
+
+            var data = Read(number);
+            if (data == null) return GraphSlotInfo.Empty(number);
+
+            return new GraphSlotInfo(number, false, data.nodes.Length, data.edges.Length, FormatSavedAt(data.savedAt));
+        }
+
+        public GraphSlotInfo[] GetAllInfo()
+        {
+            var infos = new GraphSlotInfo[SlotCount];
+            for (var i = 0; i < SlotCount; i++)
+            {
+                infos[i] = GetInfo(i + 1);
+            }
+
+            return infos;
+        }
+
+        /// <summary>
+        /// 読めなければ null。壊れたファイルや対応していない版は例外にせず null にしてログを残す。
+        /// </summary>
+        /// <remarks>
+        /// 版が違うファイルは半端に読まず必ず断る。JsonUtility は知らないキーを黙って捨て、
+        /// 無いキーを初期値のままにするので、版を見ないと「一部だけ拾えた別物のグラフ」ができる。
+        /// </remarks>
+        public GraphSaveData? Read(int number)
+        {
+            if (!IsValidSlot(number)) return null;
+
+            var path = PathOf(number);
+            if (!File.Exists(path)) return null;
+
+            try
+            {
+                var data = JsonUtility.FromJson<GraphSaveData>(File.ReadAllText(path));
+                // JsonUtility は空文字や "null" で null を返す
+                if (data == null) return null;
+
+                if (!data.IsSupportedVersion)
+                {
+                    Debug.LogError($"Graph slot {number} has unsupported version {data.version} (expected {GraphSaveData.CurrentVersion}).");
+                    return null;
+                }
+
+                return data;
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"Failed to read graph slot {number}: {e.Message}");
+                return null;
+            }
+        }
+
+        /// <remarks>
+        /// 一時ファイルへ書いてから置き換える。保存中に落ちても、既に入っていたグラフを
+        /// 中途半端なファイルで潰さないため。
+        /// </remarks>
+        public bool Write(int number, GraphSaveData data)
+        {
+            if (!IsValidSlot(number)) return false;
+
+            var path = PathOf(number);
+            var temp = path + ".tmp";
+
+            try
+            {
+                Directory.CreateDirectory(directory);
+                File.WriteAllText(temp, JsonUtility.ToJson(data, true));
+
+                // File.Replace は置き換え先が無いと失敗する
+                if (File.Exists(path)) File.Replace(temp, path, null);
+                else File.Move(temp, path);
+
+                return true;
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"Failed to write graph slot {number}: {e.Message}");
+                TryDelete(temp);
+                return false;
+            }
+        }
+
+        static void TryDelete(string path)
+        {
+            try
+            {
+                if (File.Exists(path)) File.Delete(path);
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"Failed to clean up '{path}': {e.Message}");
+            }
+        }
+
+        /// <summary>ISO 8601 を一覧向けの短い形にする。読めなければそのまま返す。</summary>
+        static string FormatSavedAt(string? savedAt)
+        {
+            if (string.IsNullOrEmpty(savedAt)) return "";
+
+            return DateTime.TryParse(savedAt, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed)
+                ? parsed.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture)
+                : savedAt;
+        }
+    }
+}

--- a/Assets/Rector/Scripts/UI/Graphs/Serialization/GraphSlotRepository.cs.meta
+++ b/Assets/Rector/Scripts/UI/Graphs/Serialization/GraphSlotRepository.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 800ac38a5a17346308f321894a21cd34

--- a/Assets/Rector/Scripts/UI/Hud/GraphSlotPageModel.cs
+++ b/Assets/Rector/Scripts/UI/Hud/GraphSlotPageModel.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using R3;
+using Rector.UI.Graphs.Serialization;
+
+#nullable enable
+
+namespace Rector.UI.Hud
+{
+    public enum GraphSlotPageMode
+    {
+        Save,
+        Load,
+    }
+
+    /// <summary>
+    /// グラフの保存スロット一覧。保存と読み込みで同じ画面をモード違いで使う。
+    /// </summary>
+    /// <remarks>
+    /// rector-page にタイトルの要素が無いので、どちらのモードで開いているかはボタンのラベルで示す。
+    /// </remarks>
+    public sealed class GraphSlotPageModel : IInitializable, IDisposable, IButtonListPageModel
+    {
+        readonly ButtonListPageView view;
+        readonly GraphSaveManager graphSaveManager;
+        readonly ReactiveProperty<bool> isVisible = new(false);
+        readonly List<RectorButtonState> buttons = new();
+
+        GraphSlotPageMode mode = GraphSlotPageMode.Load;
+
+        /// <summary>上書きの確認待ちスロット。0なら確認待ちなし。Saveモードでのみ使う。</summary>
+        int armedSlot;
+
+        Action? onExit;
+        IDisposable? disposable;
+        int index;
+
+        public GraphSlotPageModel(ButtonListPageView view, GraphSaveManager graphSaveManager)
+        {
+            this.view = view;
+            this.graphSaveManager = graphSaveManager;
+        }
+
+        void IInitializable.Initialize() => disposable = view.Bind(this);
+
+        void IDisposable.Dispose() => disposable?.Dispose();
+
+        public void Enter(GraphSlotPageMode pageMode, Action onExitAction)
+        {
+            mode = pageMode;
+            onExit = onExitAction;
+            armedSlot = 0;
+
+            // Viewが行を組み直すのは非表示->表示のときだけ。前のモードの行が残らないよう一度閉じる
+            isVisible.Value = false;
+            BuildRows();
+
+            index = 0;
+            buttons[index].IsFocused.Value = true;
+            isVisible.Value = true;
+        }
+
+        /// <summary>Saveは全枠、Loadは中身のある枠だけ並べる。</summary>
+        void BuildRows()
+        {
+            buttons.Clear();
+            foreach (var info in graphSaveManager.GetAllSlotInfo())
+            {
+                if (mode == GraphSlotPageMode.Load && info.IsEmpty) continue;
+
+                var slot = info.Number;
+                buttons.Add(new RectorButtonState(ToLabel(info), () => Submit(slot)));
+            }
+
+            // 空リストは ButtonListPageView も Navigate も想定していない
+            if (buttons.Count == 0) buttons.Add(new RectorButtonState("(no saved graphs)", () => { }));
+        }
+
+        /// <summary>Saveモード専用。Saveの行はスロット1..Nと1対1に並ぶ。</summary>
+        void RefreshLabels()
+        {
+            var infos = graphSaveManager.GetAllSlotInfo();
+            for (var i = 0; i < buttons.Count; i++)
+            {
+                buttons[i].Text.Value = ToLabel(infos[i]);
+            }
+        }
+
+        string ToLabel(GraphSlotInfo info)
+        {
+            if (info.Number == armedSlot) return $"Overwrite Slot {info.Number}?   press again to confirm";
+
+            var action = mode == GraphSlotPageMode.Save ? "Save to" : "Load";
+            var detail = info.IsEmpty
+                ? "(empty)"
+                : $"{info.NodeCount} nodes / {info.EdgeCount} edges   {info.SavedAt}";
+
+            return $"{action} Slot {info.Number}   {detail}";
+        }
+
+        void Submit(int slot)
+        {
+            if (mode == GraphSlotPageMode.Load)
+            {
+                if (graphSaveManager.Load(slot, out _)) Close();
+                return;
+            }
+
+            // 中身のあるスロットはもう一度押させて上書きの意思を確かめる。undoが無いため
+            if (armedSlot != slot && !graphSaveManager.GetSlotInfo(slot).IsEmpty)
+            {
+                armedSlot = slot;
+                RefreshLabels();
+                return;
+            }
+
+            armedSlot = 0;
+            graphSaveManager.Save(slot, out _);
+            RefreshLabels();
+        }
+
+        void Close()
+        {
+            buttons[index].IsFocused.Value = false;
+            isVisible.Value = false;
+            onExit?.Invoke();
+            onExit = null;
+        }
+
+        IEnumerable<RectorButtonState> IButtonListPageModel.GetButtons() => buttons;
+
+        ReadOnlyReactiveProperty<bool> IButtonListPageModel.IsVisible => isVisible;
+
+        void IButtonListPageModel.Submit() => buttons[index].OnClick();
+
+        void IButtonListPageModel.Cancel() => Close();
+
+        void IButtonListPageModel.Navigate(bool next)
+        {
+            // 行を移ったら確認は無かったことにする
+            if (armedSlot != 0)
+            {
+                armedSlot = 0;
+                RefreshLabels();
+            }
+
+            buttons[index].IsFocused.Value = false;
+            index = (index + (next ? 1 : -1) + buttons.Count) % buttons.Count;
+            buttons[index].IsFocused.Value = true;
+        }
+    }
+}

--- a/Assets/Rector/Scripts/UI/Hud/GraphSlotPageModel.cs.meta
+++ b/Assets/Rector/Scripts/UI/Hud/GraphSlotPageModel.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a9e4d014fbfb2455fa433bfd210378bd

--- a/Assets/Rector/Scripts/UI/Hud/HudView.cs
+++ b/Assets/Rector/Scripts/UI/Hud/HudView.cs
@@ -25,6 +25,7 @@ namespace Rector.UI.Hud
         public GraphPage GraphPage { get; }
         public ButtonListPageView ScenePageView { get; }
         public ButtonListPageView SystemPageView { get; }
+        public ButtonListPageView GraphSlotPageView { get; }
         public SettingsPageView AudioInputDevicePageView { get; }
         public SettingsPageView MidiInputDevicePageView { get; }
         public SettingsPageView OscSettingsPageView { get; }
@@ -52,6 +53,7 @@ namespace Rector.UI.Hud
             GraphPage = new GraphPage(root.Q<VisualElement>("graph-page"), graphInputAction, nodeTemplateRepository);
             ScenePageView = new ButtonListPageView(root.Q<VisualElement>("scene-page"), uiInputAction);
             SystemPageView = new ButtonListPageView(root.Q<VisualElement>("system-page"), uiInputAction);
+            GraphSlotPageView = new ButtonListPageView(root.Q<VisualElement>("graph-slot-page"), uiInputAction);
             AudioInputDevicePageView = new SettingsPageView(root.Q<VisualElement>("audio-input-device-page"), uiInputAction);
             MidiInputDevicePageView = new SettingsPageView(root.Q<VisualElement>("midi-input-device-page"), uiInputAction);
             OscSettingsPageView = new SettingsPageView(root.Q<VisualElement>("osc-settings-page"), uiInputAction);

--- a/Assets/Rector/Scripts/UI/Hud/SystemPageModel.cs
+++ b/Assets/Rector/Scripts/UI/Hud/SystemPageModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using R3;
+using Rector.UI.GraphPages;
 
 namespace Rector.UI.Hud
 {
@@ -15,10 +16,19 @@ namespace Rector.UI.Hud
         readonly OscSettingsPageModel oscSettingsPageModel;
         readonly DisplaySettingsPageModel displaySettingsPageModel;
         readonly GraphSettingsPageModel graphSettingsPageModel;
+        readonly GraphSlotPageModel graphSlotPageModel;
         readonly CopyrightNoticesPageModel copyrightNoticesPageModel;
+        readonly GraphPage graphPage;
         readonly ButtonListPageView view;
         Action onExit;
         IDisposable disposable;
+
+        const string ClearGraphLabel = "Clear Graph";
+
+        /// <summary>グラフ全消しの確認待ち。ラベルを戻すためにボタンを持っておく。</summary>
+        readonly RectorButtonState clearGraphButton;
+
+        bool clearGraphArmed;
 
         public SystemPageModel(
             AudioInputDevicePageModel audioInputDevicePageModel,
@@ -26,7 +36,9 @@ namespace Rector.UI.Hud
             OscSettingsPageModel oscSettingsPageModel,
             DisplaySettingsPageModel displaySettingsPageModel,
             GraphSettingsPageModel graphSettingsPageModel,
+            GraphSlotPageModel graphSlotPageModel,
             CopyrightNoticesPageModel copyrightNoticesPageModel,
+            GraphPage graphPage,
             ButtonListPageView view
         )
         {
@@ -35,17 +47,23 @@ namespace Rector.UI.Hud
             this.oscSettingsPageModel = oscSettingsPageModel;
             this.displaySettingsPageModel = displaySettingsPageModel;
             this.graphSettingsPageModel = graphSettingsPageModel;
+            this.graphSlotPageModel = graphSlotPageModel;
             this.copyrightNoticesPageModel = copyrightNoticesPageModel;
+            this.graphPage = graphPage;
             this.view = view;
-            buttons = new RectorButtonState[]
+            clearGraphButton = new RectorButtonState(ClearGraphLabel, ClearGraph);
+            buttons = new[]
             {
-                new("Audio Settings", ShowAudioSettings),
-                new("MIDI Settings", ShowMidiSettings),
-                new("OSC Settings", ShowOscSettings),
-                new("Display Settings", ShowDisplaySettings),
-                new("Graph Settings", ShowGraphSettings),
-                new("Copyright Notices", ShowCopyrightNotices),
-                new("Exit", ExitApplication),
+                new RectorButtonState("Audio Settings", ShowAudioSettings),
+                new RectorButtonState("MIDI Settings", ShowMidiSettings),
+                new RectorButtonState("OSC Settings", ShowOscSettings),
+                new RectorButtonState("Display Settings", ShowDisplaySettings),
+                new RectorButtonState("Graph Settings", ShowGraphSettings),
+                new RectorButtonState("Save Graph", ShowSaveGraph),
+                new RectorButtonState("Load Graph", ShowLoadGraph),
+                clearGraphButton,
+                new RectorButtonState("Copyright Notices", ShowCopyrightNotices),
+                new RectorButtonState("Exit", ExitApplication),
             };
         }
 
@@ -59,7 +77,10 @@ namespace Rector.UI.Hud
         public void Enter(Action onExitAction)
         {
             onExit = onExitAction;
+            DisarmClearGraph();
             isVisible.Value = true;
+            // 閉じずに Enter された場合に前のフォーカスが残らないよう、先に外してから先頭へ戻す
+            buttons[index].IsFocused.Value = false;
             index = 0;
             buttons[index].IsFocused.Value = true;
         }
@@ -67,6 +88,30 @@ namespace Rector.UI.Hud
         void Resume()
         {
             isVisible.Value = true;
+        }
+
+        /// <summary>グラフを全部消す。undoが無いので、もう一度押させて意思を確かめる。</summary>
+        void ClearGraph()
+        {
+            var nodeCount = graphPage.Graph.NodeCount;
+
+            // 空のグラフは消すものが無いので確認しない
+            if (nodeCount > 0 && !clearGraphArmed)
+            {
+                clearGraphArmed = true;
+                clearGraphButton.Text.Value = "Clear Graph?   press again to confirm";
+                return;
+            }
+
+            DisarmClearGraph();
+            graphPage.ClearGraph();
+            RectorLogger.GraphCleared(nodeCount);
+        }
+
+        void DisarmClearGraph()
+        {
+            clearGraphArmed = false;
+            clearGraphButton.Text.Value = ClearGraphLabel;
         }
 
 
@@ -85,6 +130,9 @@ namespace Rector.UI.Hud
 
         void IButtonListPageModel.Navigate(bool next)
         {
+            // 行を移ったら確認は無かったことにする
+            DisarmClearGraph();
+
             buttons[index].IsFocused.Value = false;
             index += next ? 1 : -1;
             index = (index + buttons.Length) % buttons.Length;
@@ -121,6 +169,18 @@ namespace Rector.UI.Hud
         {
             isVisible.Value = false;
             graphSettingsPageModel.Enter(Resume);
+        }
+
+        void ShowSaveGraph()
+        {
+            isVisible.Value = false;
+            graphSlotPageModel.Enter(GraphSlotPageMode.Save, Resume);
+        }
+
+        void ShowLoadGraph()
+        {
+            isVisible.Value = false;
+            graphSlotPageModel.Enter(GraphSlotPageMode.Load, Resume);
         }
 
         void ShowCopyrightNotices()

--- a/Assets/Rector/Scripts/UI/LayeredGraphDrawing/LayeredGraph.cs
+++ b/Assets/Rector/Scripts/UI/LayeredGraphDrawing/LayeredGraph.cs
@@ -66,6 +66,41 @@ namespace Rector.UI.LayeredGraphDrawing
             }
         }
 
+        /// <summary>
+        /// グラフ上の全ノード。Layers を歩くのと違い、Sort の前後や DummyNode に左右されない。
+        /// </summary>
+        public IEnumerable<LayeredNode> Nodes
+        {
+            get
+            {
+                foreach (var node in nodes.Values)
+                {
+                    if (node is LayeredNode layeredNode) yield return layeredNode;
+                }
+            }
+        }
+
+        /// <summary>
+        /// 全ノードとエッジを消す。グラフのロードで作り直す前に呼ぶ。
+        /// </summary>
+        /// <remarks>
+        /// RemoveNode が nodes と Layers を書き換えるので、先に id を控えてから回す。
+        /// 選択やターゲットの後始末はしないので、GraphPage 側で先に外しておくこと。
+        /// </remarks>
+        public void ClearNodes()
+        {
+            var ids = new List<NodeId>(nodes.Count);
+            foreach (var id in nodes.Keys)
+            {
+                ids.Add(id);
+            }
+
+            foreach (var id in ids)
+            {
+                RemoveNode(id);
+            }
+        }
+
         public bool TryGetNode(NodeId id, out LayeredNode node)
         {
             if (nodes.TryGetValue(id, out var n) && n is LayeredNode layeredNode)

--- a/Assets/Rector/StaticResources/UI/Hud.uxml
+++ b/Assets/Rector/StaticResources/UI/Hud.uxml
@@ -33,6 +33,9 @@
             <engine:VisualElement name="system-page" class="rector-page">
                 <engine:VisualElement name="left-list" class="rector-button-list" />
             </engine:VisualElement>
+            <engine:VisualElement name="graph-slot-page" class="rector-page">
+                <engine:VisualElement name="left-list" class="rector-button-list" />
+            </engine:VisualElement>
             <engine:VisualElement name="audio-input-device-page" class="rector-page">
                 <engine:VisualElement name="setting-list" class="rector-setting-list" />
             </engine:VisualElement>

--- a/Assets/Rector/Tests/EditMode/GraphSaveDataTests.cs
+++ b/Assets/Rector/Tests/EditMode/GraphSaveDataTests.cs
@@ -1,0 +1,276 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+using Rector.UI.Graphs;
+using Rector.UI.Graphs.Nodes;
+using Rector.UI.Graphs.Serialization;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Rector.Tests.EditMode
+{
+    /// <summary>
+    /// グラフ保存データの形式と、スロットへの読み書き。
+    /// グラフの組み立て自体は VisualElement に依存するのでここでは扱わず、CLI で確認する。
+    /// </summary>
+    public sealed class GraphSaveDataTests
+    {
+        static GraphSaveData MakeData()
+        {
+            return new GraphSaveData
+            {
+                version = GraphSaveData.CurrentVersion,
+                savedAt = "2026-08-09T00:12:34.0000000+09:00",
+                nodes = new[]
+                {
+                    new NodeSaveData
+                    {
+                        templateKind = "Code", nodeType = "MidiCcNode",
+                        ints = new[] { new IntSlotValue { index = 1, value = 42 } },
+                        bools = new[] { new BoolSlotValue { index = 0, value = true } },
+                    },
+                    new NodeSaveData
+                    {
+                        templateKind = "Code", nodeType = "FloatNode",
+                        floats = new[] { new FloatSlotValue { index = 0, value = 0.25f } },
+                        vector3s = new[] { new Vector3SlotValue { index = 3, value = new Vector3(1, 2, 3) } },
+                    },
+                },
+                edges = new[]
+                {
+                    new EdgeSaveData
+                    {
+                        fromNode = 0, fromSlot = 0, fromType = "Float",
+                        toNode = 1, toSlot = 0, toType = "Float",
+                    },
+                },
+            };
+        }
+
+        [Test]
+        public void JsonRoundTripPreservesEverything()
+        {
+            var restored = JsonUtility.FromJson<GraphSaveData>(JsonUtility.ToJson(MakeData()));
+
+            Assert.That(restored.version, Is.EqualTo(GraphSaveData.CurrentVersion));
+            Assert.That(restored.savedAt, Is.EqualTo("2026-08-09T00:12:34.0000000+09:00"));
+            Assert.That(restored.nodes.Length, Is.EqualTo(2));
+            Assert.That(restored.nodes[0].nodeType, Is.EqualTo("MidiCcNode"));
+            Assert.That(restored.nodes[0].ints[0].index, Is.EqualTo(1));
+            Assert.That(restored.nodes[0].ints[0].value, Is.EqualTo(42));
+            Assert.That(restored.nodes[0].bools[0].value, Is.True);
+            Assert.That(restored.nodes[1].floats[0].value, Is.EqualTo(0.25f));
+            Assert.That(restored.nodes[1].vector3s[0].value, Is.EqualTo(new Vector3(1, 2, 3)));
+            Assert.That(restored.edges.Length, Is.EqualTo(1));
+            Assert.That(restored.edges[0].fromType, Is.EqualTo("Float"));
+            Assert.That(restored.edges[0].toType, Is.EqualTo("Float"));
+        }
+
+        /// <remarks>
+        /// 配列フィールドの初期化子が効いていることの確認。これが崩れると、キーの無い JSON で
+        /// 配列が null になり復元側の foreach が落ちる。
+        /// </remarks>
+        [Test]
+        public void MissingArrayKeysStayEmptyRatherThanNull()
+        {
+            var restored = JsonUtility.FromJson<GraphSaveData>("{\"version\":1,\"nodes\":[{\"nodeType\":\"FloatNode\"}]}");
+
+            Assert.That(restored.edges, Is.Not.Null.And.Empty);
+            Assert.That(restored.nodes[0].floats, Is.Not.Null.And.Empty);
+            Assert.That(restored.nodes[0].ints, Is.Not.Null.And.Empty);
+            Assert.That(restored.nodes[0].bools, Is.Not.Null.And.Empty);
+            Assert.That(restored.nodes[0].vector3s, Is.Not.Null.And.Empty);
+        }
+
+        /// <remarks>version を持たない JSON が現行版として通ってしまわないこと。</remarks>
+        [Test]
+        public void VersionIsNotSupportedUnlessWritten()
+        {
+            Assert.That(JsonUtility.FromJson<GraphSaveData>("{\"nodes\":[]}").IsSupportedVersion, Is.False);
+            Assert.That(JsonUtility.FromJson<GraphSaveData>("{\"version\":99}").IsSupportedVersion, Is.False);
+            Assert.That(MakeData().IsSupportedVersion, Is.True);
+        }
+
+        // ------------------------------------------------------------------- スロット保存
+
+        static string TempDirectory() =>
+            Path.Combine(Path.GetTempPath(), "rector-graph-slot-tests", Path.GetRandomFileName());
+
+        [Test]
+        public void RepositoryWritesAndReadsBackASlot()
+        {
+            var directory = TempDirectory();
+            try
+            {
+                var repository = new GraphSlotRepository(directory);
+                Assert.That(repository.Write(1, MakeData()), Is.True);
+
+                var read = repository.Read(1);
+                Assert.That(read, Is.Not.Null);
+                Assert.That(read.nodes.Length, Is.EqualTo(2));
+                Assert.That(read.nodes[0].ints[0].value, Is.EqualTo(42));
+
+                var info = repository.GetInfo(1);
+                Assert.That(info.IsEmpty, Is.False);
+                Assert.That(info.NodeCount, Is.EqualTo(2));
+                Assert.That(info.EdgeCount, Is.EqualTo(1));
+                Assert.That(info.SavedAt, Is.EqualTo("2026-08-09 00:12"));
+            }
+            finally
+            {
+                if (Directory.Exists(directory)) Directory.Delete(directory, true);
+            }
+        }
+
+        [Test]
+        public void RepositoryOverwritesAnExistingSlot()
+        {
+            var directory = TempDirectory();
+            try
+            {
+                var repository = new GraphSlotRepository(directory);
+                repository.Write(1, MakeData());
+
+                var second = MakeData();
+                second.nodes = new[] { new NodeSaveData { templateKind = "Code", nodeType = "FloatNode" } };
+                Assert.That(repository.Write(1, second), Is.True);
+
+                Assert.That(repository.Read(1).nodes.Length, Is.EqualTo(1));
+                Assert.That(Directory.GetFiles(directory, "*.tmp"), Is.Empty);
+            }
+            finally
+            {
+                if (Directory.Exists(directory)) Directory.Delete(directory, true);
+            }
+        }
+
+        [Test]
+        public void RepositoryRefusesAnUnsupportedVersion()
+        {
+            var directory = TempDirectory();
+            try
+            {
+                Directory.CreateDirectory(directory);
+                File.WriteAllText(Path.Combine(directory, "slot1.json"), "{\"version\":99,\"nodes\":[],\"edges\":[]}");
+
+                LogAssert.Expect(LogType.Error, new System.Text.RegularExpressions.Regex("unsupported version"));
+                Assert.That(new GraphSlotRepository(directory).Read(1), Is.Null);
+            }
+            finally
+            {
+                if (Directory.Exists(directory)) Directory.Delete(directory, true);
+            }
+        }
+
+        [Test]
+        public void RepositoryReportsUnwrittenSlotsAsEmpty()
+        {
+            var repository = new GraphSlotRepository(TempDirectory());
+
+            Assert.That(repository.Read(1), Is.Null);
+
+            var info = repository.GetInfo(1);
+            Assert.That(info.IsEmpty, Is.True);
+            Assert.That(info.Number, Is.EqualTo(1));
+            Assert.That(info.SavedAt, Is.Empty);
+        }
+
+        [Test]
+        public void RepositoryRefusesSlotsOutOfRange()
+        {
+            var repository = new GraphSlotRepository(TempDirectory());
+
+            Assert.That(GraphSlotRepository.IsValidSlot(0), Is.False);
+            Assert.That(GraphSlotRepository.IsValidSlot(1), Is.True);
+            Assert.That(GraphSlotRepository.IsValidSlot(GraphSlotRepository.SlotCount), Is.True);
+            Assert.That(GraphSlotRepository.IsValidSlot(GraphSlotRepository.SlotCount + 1), Is.False);
+
+            Assert.That(repository.Write(0, MakeData()), Is.False);
+            Assert.That(repository.Read(0), Is.Null);
+        }
+
+        [Test]
+        public void RepositoryListsEverySlot()
+        {
+            var infos = new GraphSlotRepository(TempDirectory()).GetAllInfo();
+
+            Assert.That(infos.Length, Is.EqualTo(GraphSlotRepository.SlotCount));
+            Assert.That(infos[0].Number, Is.EqualTo(1));
+            Assert.That(infos[GraphSlotRepository.SlotCount - 1].Number, Is.EqualTo(GraphSlotRepository.SlotCount));
+        }
+
+        // ------------------------------------------------------------ テンプレートID
+
+        [Test]
+        public void CodeTemplateIdIsTheNodeClassName()
+        {
+            var id = NodeTemplateId.Code<FloatNode>();
+
+            Assert.That(id.Kind, Is.EqualTo(NodeTemplateKind.Code));
+            Assert.That(id.TypeName, Is.EqualTo("FloatNode"));
+            Assert.That(id, Is.EqualTo(NodeTemplateId.Code("FloatNode")));
+            Assert.That(id, Is.Not.EqualTo(NodeTemplateId.Code<SinNode>()));
+        }
+
+        [Test]
+        public void BehaviourTemplateIdIsTheGuid()
+        {
+            var guid = Guid.NewGuid();
+
+            Assert.That(NodeTemplateId.Behaviour(guid).Kind, Is.EqualTo(NodeTemplateKind.Behaviour));
+            Assert.That(NodeTemplateId.Behaviour(guid), Is.EqualTo(NodeTemplateId.Behaviour(guid)));
+            Assert.That(NodeTemplateId.Behaviour(guid), Is.Not.EqualTo(NodeTemplateId.Behaviour(Guid.NewGuid())));
+        }
+
+        /// <remarks>同じ名前でも種類が違えば別のテンプレート。直和が潰れていないことの確認。</remarks>
+        [Test]
+        public void DefaultTemplateIdIsInvalid()
+        {
+            Assert.That(default(NodeTemplateId).IsValid, Is.False);
+            Assert.That(NodeTemplateId.Code<FloatNode>().IsValid, Is.True);
+            Assert.That(NodeTemplateId.Behaviour(Guid.NewGuid()).IsValid, Is.True);
+        }
+
+        [Test]
+        public void TemplateIdSurvivesTheSaveDataRoundTrip()
+        {
+            var guid = Guid.NewGuid();
+            foreach (var id in new[] { NodeTemplateId.Code<FloatNode>(), NodeTemplateId.Behaviour(guid) })
+            {
+                var data = new NodeSaveData();
+                NodeTemplateIdSaveData.Write(id, data);
+                var json = JsonUtility.FromJson<NodeSaveData>(JsonUtility.ToJson(data));
+
+                Assert.That(NodeTemplateIdSaveData.Read(json), Is.EqualTo(id));
+            }
+        }
+
+        /// <remarks>片方のフィールドしか埋まらないこと。直和を平たく書いているので取り違えないため。</remarks>
+        [Test]
+        public void OnlyTheFieldForTheKindIsWritten()
+        {
+            var code = new NodeSaveData();
+            NodeTemplateIdSaveData.Write(NodeTemplateId.Code<FloatNode>(), code);
+            Assert.That(code.templateKind, Is.EqualTo("Code"));
+            Assert.That(code.nodeType, Is.EqualTo("FloatNode"));
+            Assert.That(code.behaviourGuid, Is.Empty);
+
+            var behaviour = new NodeSaveData();
+            NodeTemplateIdSaveData.Write(NodeTemplateId.Behaviour(Guid.NewGuid()), behaviour);
+            Assert.That(behaviour.templateKind, Is.EqualTo("Behaviour"));
+            Assert.That(behaviour.nodeType, Is.Empty);
+            Assert.That(behaviour.behaviourGuid, Is.Not.Empty);
+        }
+
+        [Test]
+        public void UnreadableTemplateIdIsInvalidRatherThanGuessed()
+        {
+            Assert.That(NodeTemplateIdSaveData.Read(new NodeSaveData()).IsValid, Is.False);
+            Assert.That(NodeTemplateIdSaveData.Read(new NodeSaveData { templateKind = "Nonsense" }).IsValid, Is.False);
+            Assert.That(NodeTemplateIdSaveData.Read(new NodeSaveData { templateKind = "Code" }).IsValid, Is.False);
+            Assert.That(NodeTemplateIdSaveData.Read(new NodeSaveData { templateKind = "Behaviour", behaviourGuid = "not-a-guid" }).IsValid, Is.False);
+            // 種類と中身が食い違うもの
+            Assert.That(NodeTemplateIdSaveData.Read(new NodeSaveData { templateKind = "Behaviour", nodeType = "FloatNode" }).IsValid, Is.False);
+        }
+    }
+}

--- a/Assets/Rector/Tests/EditMode/GraphSaveDataTests.cs.meta
+++ b/Assets/Rector/Tests/EditMode/GraphSaveDataTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c876007259a59483fa2b3a372049c8ee


### PR DESCRIPTION
Closes #81.

Graphs were lost on exit, so every session started by rebuilding the patch by hand. MIDI assignments in particular had to be redone each time.

## What it does

Save and load live in the system menu, backed by 8 fixed slots under `persistentDataPath/graphs`. The HUD has no text entry, so slots are numbered rather than named; the list shows node and edge counts and the save time.

**Loading adds to the current graph rather than replacing it.** A saved slot doubles as a preset that can be dropped in mid-session, and the nodes land in the group of whatever was selected when the menu was opened. `Clear Graph` covers the replace case, and also fills a gap — there was no way to empty the graph without deleting nodes one at a time.

Both destructive actions (overwriting an occupied slot, clearing the graph) ask for a second press on the same button before they commit. Moving the cursor cancels. Loading is non-destructive and goes through in one press.

Saved per node: the template it came from, and the values of input slots with no edge attached. Connected inputs are driven by their edge after the load, so storing them would only add a transient. Callback and Transform inputs are left out — the first has no value, the second is a scene reference. MIDI note and CC numbers are ordinary int inputs, so they come back without any special handling.

Nodes from a background scene are left out. Their templates only exist while that scene is loaded, so a saved graph could not name them reliably; restoring them is worth its own issue.

## Template identity

`NodeTemplateId` was a per-startup counter, which cannot be persisted. It is now the template's real identity, and the two ways templates are made turn out to be the only two cases:

- `Code<T>()` — one template per node class, keyed on the class name
- `Behaviour(guid)` — one per `NodeBehaviour`, keyed on its guid (VFX, cameras, scene objects)

Nothing in the file derives from a display name any more, so renaming a VFX prefab, a camera GameObject or a `NodeCategory` member no longer invalidates saved graphs. Deleting a node class now fails the build rather than failing at load. `Node.SaveKey`, added earlier in this branch as a second identifier, is gone.

## File format

```json
{
  "version": 1,
  "savedAt": "2026-08-09T03:22:05.1755460+09:00",
  "nodes": [
    { "templateKind": "Code", "nodeType": "MidiCcNode", "behaviourGuid": "",
      "floats": [], "ints": [ { "index": 1, "value": 42 } ], "bools": [], "vector3s": [] }
  ],
  "edges": [
    { "fromNode": 0, "fromSlot": 0, "fromType": "Float",
      "toNode": 1, "toSlot": 0, "toType": "Float" } ]
}
```

Slots are referenced by index alone. Edges also record the slot types, so a node whose slots were reordered drops the edge instead of quietly rewiring it to whatever now sits at that index. Values carry no type field because the array they live in already is the type; recording it twice would let a file disagree with itself.

`version` has no default, so a JSON without one is not mistaken for v1, and anything other than the current version is refused outright rather than half-read. Writes go through a temp file and `File.Replace`, so a crash mid-save cannot destroy the slot that was already there.

## Verification

- EditMode tests: 44/44. New coverage for the JSON round trip, the template id sum type, version rejection, and slot writes.
- Driven end to end through the CLI in play mode: round trip of code / VFX / camera nodes with their values, additive load keeping existing nodes, group targeting, the two-press confirmations, and the empty-slot and no-saved-graphs cases.
- Damaged files were checked by hand-editing them: an unknown node type, an unknown guid, a changed slot type, an out-of-range slot index and a future version each drop only what they should, and say so in the HUD log.

## New CLI commands

`rector_graph_slots`, `rector_save_graph`, `rector_load_graph`, `rector_clear_graph`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)