### PR TITLE
fix: correct a scene counter, three stale comments, and a timezone-dependent test

### DIFF
--- a/Assets/Rector/Scripts/Audio/AudioInputStream.cs
+++ b/Assets/Rector/Scripts/Audio/AudioInputStream.cs
@@ -50,7 +50,7 @@ namespace Rector.Audio
         }
 
         /// <summary>
-        /// 音声データ（波形）。マイフレームサイズが変わるので注意。
+        /// 音声データ（波形）。毎フレームサイズが変わるので注意。
         /// </summary>
         public NativeSlice<float> AudioDataSlice => levelTracker.audioDataSlice;
 

--- a/Assets/Rector/Scripts/Cli/CliClient.cs
+++ b/Assets/Rector/Scripts/Cli/CliClient.cs
@@ -132,9 +132,7 @@ namespace Rector.Cli
             return new { success = true, node = ToNodeSummaryDto(node) };
         }
 
-        // HUD ではノード削除だけが長押し (NodeSelectionInputHandler)。エッジ削除も
-        // シーン切替も単押しなので、Rector 自身が「慎重にやる操作」と決めているのは
-        // これだけ。undo もないため CLI からも一手間かける。
+        // ノード削除には undo が無い。CLI は誤爆しても取り返しがつかないので confirm を要求する。
         object RemoveNode(uint id, bool confirm)
         {
             if (!graphPage.Graph.TryGetNode(new NodeId(id), out var node)) return UnknownNode(id);

--- a/Assets/Rector/Scripts/Editor/NodeBehaviourGUIDInitializer.cs
+++ b/Assets/Rector/Scripts/Editor/NodeBehaviourGUIDInitializer.cs
@@ -15,7 +15,10 @@ namespace Rector.Editor
             var usedGuids = new HashSet<string>();
             var totalEmptyFixed = 0;
             var totalDuplicatesFixed = 0;
-            var modifiedSceneCount = 0;
+
+            // 空GUIDの修正と重複の修正は別々にシーンを開き直すので、両方で直したシーンは
+            // 2回通る。数えたいのは保存したシーンの数なのでパスで集める
+            var modifiedScenePaths = new HashSet<string>();
 
             var sceneGuids = AssetDatabase.FindAssets("t:Scene", new[] { "Assets/Rector" });
             var originalSceneSetup = EditorSceneManager.GetSceneManagerSetup();
@@ -42,7 +45,7 @@ namespace Rector.Editor
                     }
                 }
 
-                // Second pass: fix empty GUIDs and duplicates
+                // Second pass: fix empty GUIDs
                 foreach (var sceneGuid in sceneGuids)
                 {
                     var scenePath = AssetDatabase.GUIDToAssetPath(sceneGuid);
@@ -76,7 +79,7 @@ namespace Rector.Editor
                     {
                         EditorSceneManager.MarkSceneDirty(scene);
                         EditorSceneManager.SaveScene(scene);
-                        modifiedSceneCount++;
+                        modifiedScenePaths.Add(scenePath);
                         Debug.Log($"Saved scene: {scenePath}");
                     }
                 }
@@ -118,7 +121,7 @@ namespace Rector.Editor
                     {
                         EditorSceneManager.MarkSceneDirty(scene);
                         EditorSceneManager.SaveScene(scene);
-                        if (!sceneModified) modifiedSceneCount++; // Count only if not already counted
+                        modifiedScenePaths.Add(scenePath);
                         Debug.Log($"Saved scene: {scenePath}");
                     }
                 }
@@ -166,7 +169,7 @@ namespace Rector.Editor
             if (totalFixed > 0)
             {
                 Debug.Log($"NodeBehaviour GUID initialization complete. Fixed {totalFixed} NodeBehaviours " +
-                          $"({totalEmptyFixed} empty, {totalDuplicatesFixed} duplicates) in {modifiedSceneCount} scenes.");
+                          $"({totalEmptyFixed} empty, {totalDuplicatesFixed} duplicates) in {modifiedScenePaths.Count} scenes.");
             }
             else
             {

--- a/Assets/Rector/Scripts/UI/LayeredGraphDrawing/GraphSorter.cs
+++ b/Assets/Rector/Scripts/UI/LayeredGraphDrawing/GraphSorter.cs
@@ -298,7 +298,7 @@ namespace Rector.UI.LayeredGraphDrawing
             return x;
 
             // block内のnodeのxとsinkを決める
-            // blockとsinkが共通のblockがある場合は先にそれを計算する（ので再起処理になってる）
+            // blockとsinkが共通のblockがある場合は先にそれを計算する（ので再帰処理になってる）
             void PlaceBlock(ILayeredNode rootNode)
             {
                 if (x.TryAdd(rootNode.Id, 0f))

--- a/Assets/Rector/Scripts/UI/LayeredGraphDrawing/ILayeredNode.cs
+++ b/Assets/Rector/Scripts/UI/LayeredGraphDrawing/ILayeredNode.cs
@@ -18,10 +18,10 @@ namespace Rector.UI.LayeredGraphDrawing
         // static
         bool IsDummy { get; }
 
-        // nealy static
+        // nearly static
         float Width { get; }
 
-        // nealy static
+        // nearly static
         float Height { get; }
 
         // dynamic

--- a/Assets/Rector/Scripts/UI/LayeredGraphDrawing/LayeredGraph.cs
+++ b/Assets/Rector/Scripts/UI/LayeredGraphDrawing/LayeredGraph.cs
@@ -241,7 +241,7 @@ namespace Rector.UI.LayeredGraphDrawing
             }
         }
 
-        // fromからtoに向かうedgeがあるかどうかを再起的に調べる
+        // fromからtoに向かうedgeがあるかどうかを再帰的に調べる
         bool CheckRecursively(LayeredNode from, LayeredNode to)
         {
             if (from == to) return true;

--- a/Assets/Rector/Scripts/UI/LayeredGraphDrawing/NodeGroups.cs
+++ b/Assets/Rector/Scripts/UI/LayeredGraphDrawing/NodeGroups.cs
@@ -38,7 +38,7 @@ namespace Rector.UI.LayeredGraphDrawing
         public const int MaxCount = 8;
         public const int DefaultCount = 4;
 
-        /// <summary>グループの最小幅。NodeView.Widthはレイアウト解決前は0なので、その揺れもここで吸収される。</summary>
+        /// <summary>グループの最小幅。中身が細いときに枠が潰れないようにする。</summary>
         public const float MinWidth = 240f;
 
         /// <summary>グループの左右と上の内側の余白。左borderとノードがくっついて見えなくなるのを防ぐ。</summary>

--- a/Assets/Rector/Tests/EditMode/GraphSaveDataTests.cs
+++ b/Assets/Rector/Tests/EditMode/GraphSaveDataTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.IO;
 using NUnit.Framework;
 using Rector.UI.Graphs;
@@ -15,12 +16,14 @@ namespace Rector.Tests.EditMode
     /// </summary>
     public sealed class GraphSaveDataTests
     {
+        const string SavedAtRaw = "2026-08-09T00:12:34.0000000+09:00";
+
         static GraphSaveData MakeData()
         {
             return new GraphSaveData
             {
                 version = GraphSaveData.CurrentVersion,
-                savedAt = "2026-08-09T00:12:34.0000000+09:00",
+                savedAt = SavedAtRaw,
                 nodes = new[]
                 {
                     new NodeSaveData
@@ -114,7 +117,11 @@ namespace Rector.Tests.EditMode
                 Assert.That(info.IsEmpty, Is.False);
                 Assert.That(info.NodeCount, Is.EqualTo(2));
                 Assert.That(info.EdgeCount, Is.EqualTo(1));
-                Assert.That(info.SavedAt, Is.EqualTo("2026-08-09 00:12"));
+                // FormatSavedAt はオフセット付きの保存値をローカル時刻へ直して見せるので、
+                // 表示文字列を固定すると JST 以外で落ちる。保存した瞬間に戻ることだけ見る
+                var shown = DateTime.Parse(info.SavedAt, CultureInfo.InvariantCulture);
+                var expected = DateTimeOffset.Parse(SavedAtRaw, CultureInfo.InvariantCulture).LocalDateTime;
+                Assert.That(shown, Is.EqualTo(new DateTime(expected.Year, expected.Month, expected.Day, expected.Hour, expected.Minute, 0)));
             }
             finally
             {


### PR DESCRIPTION
Part of #85. Scope deliberately narrow: **bugs and statements that were factually wrong** — nothing else.

An earlier version of this PR also carried test restructuring, comment cleanup, and structural changes. Those are set aside so the design direction can be decided first; the full branch is kept as `issue-85-full` and the investigation behind it is in the [comment on #85](https://github.com/shivaduke28/Rector/issues/85#issuecomment-5227887972).

## What this fixes

**A scene counter that under-reported.** `NodeBehaviourGUIDInitializer` tells you how many scenes it saved, but in the duplicate-fixing pass the increment sat behind `if (!sceneModified)` inside a block that only runs when `sceneModified` is true. Scenes fixed only for duplicate GUIDs never made it into the total. The guard was there for a real reason — the two passes reopen every scene independently, so a scene fixed by both would be counted twice — so this collects scene paths in a set instead of removing the check.

**Three comments that described code they don't depend on, and had drifted from it.** `CliClient` said node removal was the only hold gesture in the HUD; `NodeSelectionInputHandler.RemoveEdge` is one as well, so the comment now states the CLI's own reason for requiring `confirm`. `NodeGroups` said an unresolved `NodeView` width reads as zero while `GraphSorter` says NaN — `GraphSorter` is right, and the claim is dropped from the file that doesn't own it. The GUID initializer labelled its second pass as fixing duplicates, which is the third pass's job.

**A test that only passed in JST.** `GraphSaveDataTests` compared the displayed timestamp to the literal `"2026-08-09 00:12"`. `FormatSavedAt` parses an offset-bearing timestamp with `DateTime.TryParse`, which converts to the machine's local time, so under UTC the same data renders as `2026-08-08 15:12` and the test fails. It now checks that the shown value parses back to the instant that was saved, without fixing the display format.

Plus three typos (再起 → 再帰, マイフレーム → 毎フレーム, nealy → nearly).

## Verification

- EditMode tests: 44/44 green (`unity command run_tests`)
- `unity command recompile` clean
- `dotnet format Rector.csproj` on the 8 touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XHBsg7bCZREg5Fpt8MTU52