### PR TITLE
add: keyboard layout to the HUD input guide (issue #86)

### DIFF
--- a/Assets/Rector/Scripts/UI/GraphPages/InputGuideChip.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/InputGuideChip.cs
@@ -1,0 +1,45 @@
+using UnityEngine.UIElements;
+
+namespace Rector.UI.GraphPages
+{
+    /// <summary>
+    /// ガイドの1項目。「キー名(ボタン名)」と「動作」を同じ色の下地に分けて載せ、キー名だけ枠で囲む。
+    /// 押すものが四角として立つので、文字の並びから目で拾えるようになる。
+    /// 空きは動作を「-」にして減光し、何も無いことを見せる。
+    /// </summary>
+    public sealed class InputGuideChip : VisualElement
+    {
+        readonly Label key;
+        readonly Label action;
+
+        public InputGuideChip(string keyText = "", string actionText = "")
+        {
+            AddToClassList(InputGuideClassNames.Chip);
+            pickingMode = PickingMode.Ignore;
+
+            key = new Label(keyText) { pickingMode = PickingMode.Ignore };
+            key.AddToClassList(InputGuideClassNames.Key);
+            Add(key);
+
+            action = new Label(actionText) { pickingMode = PickingMode.Ignore };
+            action.AddToClassList(InputGuideClassNames.Action);
+            Add(action);
+        }
+
+        public void SetKey(string value) => key.text = value;
+
+        /// <summary>
+        /// キー名を枠で囲むか。△□◯✕のような記号はそれ自体がボタンの形なので、
+        /// 枠を足すと二重になる。文字で呼ぶボタン(L2, Y, TAB)だけ囲む。
+        /// </summary>
+        public void SetKeyFramed(bool framed) => key.EnableInClassList(InputGuideClassNames.KeyPlain, !framed);
+
+        public void SetAction(string value) => action.text = value ?? "-";
+
+        public void SetState(bool enabled, bool active)
+        {
+            EnableInClassList(InputGuideClassNames.ChipDisabled, !enabled);
+            EnableInClassList(InputGuideClassNames.ChipActive, enabled && active);
+        }
+    }
+}

--- a/Assets/Rector/Scripts/UI/GraphPages/InputGuideChip.cs.meta
+++ b/Assets/Rector/Scripts/UI/GraphPages/InputGuideChip.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6cf15103c3523418cae3fefb808cb303

--- a/Assets/Rector/Scripts/UI/GraphPages/InputGuideClassNames.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/InputGuideClassNames.cs
@@ -1,0 +1,26 @@
+namespace Rector.UI.GraphPages
+{
+    /// <summary>
+    /// 操作ガイドのUSSクラス名。パッド用とキーボード用のレイアウトでチップの見た目
+    /// (減光・反転)を共有するので、名前は一箇所にまとめておく。
+    /// </summary>
+    public static class InputGuideClassNames
+    {
+        public const string Root = "rector-input-guide";
+        public const string Pad = Root + "__pad";
+        public const string Keyboard = Root + "__keyboard";
+        public const string Row = Root + "__row";
+        public const string Cell = Root + "__cell";
+        public const string CellLeft = Cell + "--left";
+        public const string CellRight = Cell + "--right";
+        public const string Chip = Root + "__chip";
+        public const string ChipActive = Chip + "--active";
+        public const string ChipDisabled = Chip + "--disabled";
+        public const string Gap = Root + "__gap";
+        public const string FaceOffset = Root + "__face-offset";
+        public const string ShoulderGutter = Root + "__shoulder-gutter";
+        public const string Key = Root + "__key";
+        public const string KeyPlain = Key + "--plain";
+        public const string Action = Root + "__action";
+    }
+}

--- a/Assets/Rector/Scripts/UI/GraphPages/InputGuideClassNames.cs.meta
+++ b/Assets/Rector/Scripts/UI/GraphPages/InputGuideClassNames.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 93da0daa354df42a4a038dcb8b32c52f

--- a/Assets/Rector/Scripts/UI/GraphPages/InputGuideContents.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/InputGuideContents.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+
+namespace Rector.UI.GraphPages
+{
+    /// <summary>
+    /// ステートごとの操作ガイドの中身。表記(パッド名/キー名)とレイアウトから切り離してあるので、
+    /// <see cref="PadGuideView"/> と <see cref="KeyboardGuideView"/> が同じ表を見る。
+    /// </summary>
+    public sealed class GuideContent
+    {
+        public string FaceTop;
+        public string FaceLeft;
+        public string FaceRight;
+        public string FaceBottom;
+        public bool Mute;
+
+        /// <summary>右下ボタンのセルの文言。nullなら無効(減光)。</summary>
+        public string Param;
+
+        /// <summary>下面ボタンとの同時押し(差し替え接続)。表記が「R1+✕」のようになる。</summary>
+        public bool ParamCombo;
+
+        /// <summary>右下ボタンを握っていることが前提のステート(パラメータ表示中)で反転させる。</summary>
+        public bool ParamActive;
+
+        public bool Grab;
+    }
+
+    public static class InputGuideContents
+    {
+        public const string ParamLabel = "PARAM";
+        public const string ReplaceLabel = "REPLACE";
+
+        static readonly Dictionary<GraphPageState, GuideContent> Contents = new()
+        {
+            [GraphPageState.NodeSelection] = new GuideContent
+            {
+                FaceTop = "ADD (DELETE)",
+                FaceLeft = "ACTION",
+                FaceRight = "(CUT)",
+                FaceBottom = "SLOT",
+                Mute = true,
+                Param = ParamLabel,
+                Grab = true,
+            },
+            [GraphPageState.SlotSelection] = new GuideContent
+            {
+                FaceLeft = "ACTION",
+                FaceRight = "BACK (CUT)",
+                FaceBottom = "TARGET",
+                Mute = true,
+            },
+            [GraphPageState.TargetNodeSelection] = new GuideContent
+            {
+                FaceTop = "CONTINUE",
+                FaceLeft = "ACTION",
+                FaceRight = "BACK",
+                FaceBottom = "SLOT",
+                Mute = true,
+            },
+            [GraphPageState.TargetSlotSelection] = new GuideContent
+            {
+                FaceTop = "CONTINUE",
+                FaceLeft = "ACTION",
+                FaceRight = "BACK",
+                FaceBottom = "CONNECT/CUT",
+                Mute = true,
+                Param = ReplaceLabel,
+                ParamCombo = true,
+            },
+            [GraphPageState.NodeCreation] = new GuideContent
+            {
+                FaceRight = "BACK",
+                FaceBottom = "OK",
+            },
+            [GraphPageState.NodeParameter] = new GuideContent
+            {
+                FaceLeft = "STEP",
+                FaceRight = "CLOSE",
+                Mute = true,
+                Param = ParamLabel,
+                ParamActive = true,
+            },
+        };
+
+        public static GuideContent Get(GraphPageState state) => Contents[state];
+    }
+}

--- a/Assets/Rector/Scripts/UI/GraphPages/InputGuideContents.cs.meta
+++ b/Assets/Rector/Scripts/UI/GraphPages/InputGuideContents.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 603bf68528b344beea58e938925de6cc

--- a/Assets/Rector/Scripts/UI/GraphPages/InputGuideMode.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/InputGuideMode.cs
@@ -1,10 +1,14 @@
 namespace Rector.UI.GraphPages
 {
-    /// <summary>操作ガイドの表記。パッドごとにボタン名が違うので、自動検出ではなく設定で選ぶ。</summary>
+    /// <summary>
+    /// 操作ガイドの表記。パッドごとにボタン名が違うので、自動検出ではなく設定で選ぶ。
+    /// Keyboardはボタン名だけでなくレイアウトごと別物になる。
+    /// </summary>
     public enum InputGuideMode
     {
         Off,
         DualShock,
         Xbox,
+        Keyboard,
     }
 }

--- a/Assets/Rector/Scripts/UI/GraphPages/InputGuideSettings.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/InputGuideSettings.cs
@@ -20,7 +20,7 @@ namespace Rector.UI.GraphPages
             // 保存された値が範囲外でも壊れないようclampして読む
             var saved = PlayerPrefs.GetInt(PrefsKey, (int)InputGuideMode.DualShock);
             mode = new ReactiveProperty<InputGuideMode>(
-                (InputGuideMode)Mathf.Clamp(saved, (int)InputGuideMode.Off, (int)InputGuideMode.Xbox));
+                (InputGuideMode)Mathf.Clamp(saved, (int)InputGuideMode.Off, (int)InputGuideMode.Keyboard));
         }
 
         public void SetMode(InputGuideMode value)

--- a/Assets/Rector/Scripts/UI/GraphPages/InputGuideView.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/InputGuideView.cs
@@ -1,184 +1,32 @@
 using System;
-using System.Collections.Generic;
 using R3;
 using UnityEngine.UIElements;
 
 namespace Rector.UI.GraphPages
 {
     /// <summary>
-    /// グラフゾーン右下の操作ガイド。中心軸を挟んだ2カラムの固定グリッドに、
-    /// ボタンの物理配置(L2/R2が上段、L1/R1が下段、△□○✕は菱形)を写す。
-    /// 左セルは右揃えで軸に吸着、右セルは左揃え。△と✕は右カラム先頭なので記号のxが揃う。
-    /// ステートで場所が動くと目で追えないので、構造と位置は常に固定のまま
-    /// 文言と有効/無効(減光)・ホールド中の反転だけを切り替える。
-    /// 空きボタンは「記号 -」で「何も無い」ことを見せる。
-    /// ボタン名はDualShock/Xboxを設定で選ぶ(<see cref="InputGuideMode"/>)。位置は同じで表記だけ変わる。
-    /// キーボード専用キーとスティック系(ズーム/パン/リセット)は載せない。
+    /// グラフゾーン右下の操作ガイド。表記だけでなくレイアウトごと差し替わるので、
+    /// パッド用(<see cref="PadGuideView"/>)とキーボード用(<see cref="KeyboardGuideView"/>)を
+    /// 両方持って設定(<see cref="InputGuideMode"/>)で表示を切り替える。
+    /// 中身は <see cref="InputGuideContents"/> の1つの表を両方が読む。
     /// </summary>
     public sealed class InputGuideView : VisualElement
     {
-        const string UssClassName = "rector-input-guide";
-        const string RowClassName = UssClassName + "__row";
-        const string CellClassName = UssClassName + "__cell";
-        const string CellLeftClassName = CellClassName + "--left";
-        const string CellRightClassName = CellClassName + "--right";
-        const string ChipClassName = UssClassName + "__chip";
-        const string ChipActiveClassName = ChipClassName + "--active";
-        const string ChipDisabledClassName = ChipClassName + "--disabled";
-        const string GapClassName = UssClassName + "__gap";
-        const string FaceOffsetClassName = UssClassName + "__face-offset";
-        const string ShoulderGutterClassName = UssClassName + "__shoulder-gutter";
-
-        const string ParamLabel = "PARAM";
-        const string ReplaceLabel = "REPLACE";
-
-        /// <summary>
-        /// パッドごとのボタン名。位置(上/左/右/下、ショルダー4種)は共通で、呼び名だけが違う。
-        /// </summary>
-        readonly struct ButtonNames
-        {
-            public readonly string FaceTop;
-            public readonly string FaceLeft;
-            public readonly string FaceRight;
-            public readonly string FaceBottom;
-            public readonly string UpperLeft;
-            public readonly string UpperRight;
-            public readonly string LowerLeft;
-            public readonly string LowerRight;
-
-            public ButtonNames(string faceTop, string faceLeft, string faceRight, string faceBottom,
-                string upperLeft, string upperRight, string lowerLeft, string lowerRight)
-            {
-                FaceTop = faceTop;
-                FaceLeft = faceLeft;
-                FaceRight = faceRight;
-                FaceBottom = faceBottom;
-                UpperLeft = upperLeft;
-                UpperRight = upperRight;
-                LowerLeft = lowerLeft;
-                LowerRight = lowerRight;
-            }
-        }
-
-        // ◯はU+25CBだとJetBrains Monoにグリフが無く豆腐(□)になるので、U+25EFを使う
-        static readonly ButtonNames DualShockNames = new("△", "□", "◯", "✕", "L2", "R2", "L1", "R1");
-        static readonly ButtonNames XboxNames = new("Y", "X", "B", "A", "LT", "RT", "LB", "RB");
-
-        sealed class GuideContent
-        {
-            public string FaceTop;
-            public string FaceLeft;
-            public string FaceRight;
-            public string FaceBottom;
-            public bool Mute;
-
-            /// <summary>右下ボタンのセルの文言。nullなら無効(減光)。</summary>
-            public string Param;
-
-            /// <summary>下面ボタンとの同時押し(差し替え接続)。表記が「R1+✕」のようになる。</summary>
-            public bool ParamCombo;
-
-            /// <summary>右下ボタンを握っていることが前提のステート(パラメータ表示中)で反転させる。</summary>
-            public bool ParamActive;
-
-            public bool Grab;
-        }
-
-        static readonly Dictionary<GraphPageState, GuideContent> Contents = new()
-        {
-            [GraphPageState.NodeSelection] = new GuideContent
-            {
-                FaceTop = "ADD (DELETE)",
-                FaceLeft = "ACTION",
-                FaceRight = "(CUT)",
-                FaceBottom = "SLOT",
-                Mute = true,
-                Param = ParamLabel,
-                Grab = true,
-            },
-            [GraphPageState.SlotSelection] = new GuideContent
-            {
-                FaceLeft = "ACTION",
-                FaceRight = "BACK (CUT)",
-                FaceBottom = "TARGET",
-                Mute = true,
-            },
-            [GraphPageState.TargetNodeSelection] = new GuideContent
-            {
-                FaceTop = "CONTINUE",
-                FaceLeft = "ACTION",
-                FaceRight = "BACK",
-                FaceBottom = "SLOT",
-                Mute = true,
-            },
-            [GraphPageState.TargetSlotSelection] = new GuideContent
-            {
-                FaceTop = "CONTINUE",
-                FaceLeft = "ACTION",
-                FaceRight = "BACK",
-                FaceBottom = "CONNECT/CUT",
-                Mute = true,
-                Param = ReplaceLabel,
-                ParamCombo = true,
-            },
-            [GraphPageState.NodeCreation] = new GuideContent
-            {
-                FaceRight = "BACK",
-                FaceBottom = "OK",
-            },
-            [GraphPageState.NodeParameter] = new GuideContent
-            {
-                FaceLeft = "STEP",
-                FaceRight = "CLOSE",
-                Mute = true,
-                Param = ParamLabel,
-                ParamActive = true,
-            },
-        };
-
-        readonly Label lockChip;
-        readonly Label grabChip;
-        readonly Label muteChip;
-        readonly Label paramChip;
-        readonly Label faceTop;
-        readonly Label faceLeft;
-        readonly Label faceRight;
-        readonly Label faceBottom;
+        readonly PadGuideView padView = new();
+        readonly KeyboardGuideView keyboardView = new();
 
         GraphPageState currentState;
         bool grabHeld;
         bool lockHeld;
-        ButtonNames names = DualShockNames;
 
         public InputGuideView()
         {
-            AddToClassList(UssClassName);
+            AddToClassList(InputGuideClassNames.Root);
             pickingMode = PickingMode.Ignore;
 
-            // セルは透明な位置決め箱で、背景の塗りは文字ぴったりの内側チップにだけ載せる
-            var lockCell = CreateCell(string.Empty, CellLeftClassName, out lockChip);
-            var grabCell = CreateCell(string.Empty, CellRightClassName, out grabChip);
-            var muteCell = CreateCell(string.Empty, CellLeftClassName, out muteChip);
-            var paramCell = CreateCell(string.Empty, CellRightClassName, out paramChip);
-            var faceTopCell = CreateCell(string.Empty, CellRightClassName, out faceTop);
-            var faceLeftCell = CreateCell(string.Empty, CellLeftClassName, out faceLeft);
-            var faceRightCell = CreateCell(string.Empty, CellRightClassName, out faceRight);
-            var faceBottomCell = CreateCell(string.Empty, CellRightClassName, out faceBottom);
-
-            // R側は△ボタンの右端あたりから始めて、L/R間に余白を作る
-            Add(CreateRow(lockCell, CreateShoulderGutter(), grabCell));
-            Add(CreateRow(muteCell, CreateShoulderGutter(), paramCell));
-
-            var gap = new VisualElement { pickingMode = PickingMode.Ignore };
-            gap.AddToClassList(GapClassName);
-            Add(gap);
-
-            // 菱形: △✕は中心軸の列、□は軸の左、○は軸から右へオフセット(パッドの形)
-            Add(CreateRow(CreateBlankCell(), faceTopCell));
-            var faceOffset = new VisualElement { pickingMode = PickingMode.Ignore };
-            faceOffset.AddToClassList(FaceOffsetClassName);
-            Add(CreateRow(faceLeftCell, faceOffset, faceRightCell));
-            Add(CreateRow(CreateBlankCell(), faceBottomCell));
+            Add(padView);
+            Add(keyboardView);
+            keyboardView.style.display = DisplayStyle.None;
         }
 
         public IDisposable Bind(
@@ -206,82 +54,24 @@ namespace Rector.UI.GraphPages
                 mode.Subscribe(x =>
                 {
                     style.display = x == InputGuideMode.Off ? DisplayStyle.None : DisplayStyle.Flex;
-                    names = x == InputGuideMode.Xbox ? XboxNames : DualShockNames;
+
+                    var keyboard = x == InputGuideMode.Keyboard;
+                    padView.style.display = keyboard ? DisplayStyle.None : DisplayStyle.Flex;
+                    keyboardView.style.display = keyboard ? DisplayStyle.Flex : DisplayStyle.None;
+                    padView.SetXbox(x == InputGuideMode.Xbox);
+
                     UpdateContent();
                 })
             );
         }
 
+        // 隠れている方も一緒に更新する。ラベル代入が十数個増えるだけで、
+        // 切り替え時に古い表示が残る分岐を持たない方が安い。
         void UpdateContent()
         {
-            var content = Contents[currentState];
-
-            SetFace(faceTop, names.FaceTop, content.FaceTop);
-            SetFace(faceLeft, names.FaceLeft, content.FaceLeft);
-            SetFace(faceRight, names.FaceRight, content.FaceRight);
-            SetFace(faceBottom, names.FaceBottom, content.FaceBottom);
-
-            lockChip.text = $"{names.UpperLeft} LOCK";
-            SetChip(lockChip, true, lockHeld);
-            grabChip.text = $"{names.UpperRight} GRAB";
-            SetChip(grabChip, content.Grab, grabHeld);
-            muteChip.text = $"{names.LowerLeft} MUTE";
-            SetChip(muteChip, content.Mute, false);
-            // 差し替え接続は下面ボタンとの同時押しなので、そのまま「R1+✕」と見せる
-            var paramPrefix = content.ParamCombo ? $"{names.LowerRight}+{names.FaceBottom}" : names.LowerRight;
-            paramChip.text = $"{paramPrefix} {content.Param ?? ParamLabel}";
-            SetChip(paramChip, content.Param != null, content.ParamActive);
-        }
-
-        /// <summary>空きポジションは「ボタン名 -」の減光表示にして、何も無いことを見せる。</summary>
-        static void SetFace(Label label, string button, string text)
-        {
-            label.text = text == null ? $"{button} -" : $"{button} {text}";
-            label.EnableInClassList(ChipDisabledClassName, text == null);
-        }
-
-        static void SetChip(Label chip, bool enabled, bool active)
-        {
-            chip.EnableInClassList(ChipDisabledClassName, !enabled);
-            chip.EnableInClassList(ChipActiveClassName, enabled && active);
-        }
-
-        static VisualElement CreateCell(string text, string sideClassName, out Label chip)
-        {
-            var cell = new VisualElement { pickingMode = PickingMode.Ignore };
-            cell.AddToClassList(CellClassName);
-            cell.AddToClassList(sideClassName);
-
-            chip = new Label(text) { pickingMode = PickingMode.Ignore };
-            chip.AddToClassList(ChipClassName);
-            cell.Add(chip);
-            return cell;
-        }
-
-        static VisualElement CreateBlankCell()
-        {
-            var cell = new VisualElement { pickingMode = PickingMode.Ignore };
-            cell.AddToClassList(CellClassName);
-            return cell;
-        }
-
-        static VisualElement CreateShoulderGutter()
-        {
-            var gutter = new VisualElement { pickingMode = PickingMode.Ignore };
-            gutter.AddToClassList(ShoulderGutterClassName);
-            return gutter;
-        }
-
-        static VisualElement CreateRow(params VisualElement[] children)
-        {
-            var row = new VisualElement { pickingMode = PickingMode.Ignore };
-            row.AddToClassList(RowClassName);
-            foreach (var child in children)
-            {
-                row.Add(child);
-            }
-
-            return row;
+            var content = InputGuideContents.Get(currentState);
+            padView.Apply(content, grabHeld, lockHeld);
+            keyboardView.Apply(content, grabHeld, lockHeld);
         }
     }
 }

--- a/Assets/Rector/Scripts/UI/GraphPages/KeyboardGuideView.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/KeyboardGuideView.cs
@@ -1,0 +1,110 @@
+using UnityEngine.UIElements;
+
+namespace Rector.UI.GraphPages
+{
+    /// <summary>
+    /// キーボード用の操作ガイド。パッドと違ってキーの物理配置を写しても意味が無いので、
+    /// 押し方でまとめた3行に「キー名 動作」のチップを横へ流す。
+    /// 1行目はビューを動かすキー、2行目は押しながら使う修飾キー、3行目は単押しのアクション。
+    /// キーの縦揃えはあきらめる代わりに、縦の場所を大きく節約している。
+    /// 行間は全部そろえて詰める。グループの切れ目は中身の性質で読めるので、
+    /// 空きを足すより詰めた方が右下の占有が小さくて済む。
+    /// 1行目のパン/ズーム/リセットはパッド版がスティック扱いで省いているもので、
+    /// キーボードにはスティックが無くキー名を知らないと動かせないためここだけ載せる
+    /// (移動のWASDは説明が要らないので出さない)。
+    /// 2・3行目はパッド版と同じ内容を共有する(<see cref="InputGuideContents"/>)。
+    /// 行の幅は文言で伸び縮みするので、右端を揃えてガイドの右辺だけは動かさない。
+    /// </summary>
+    public sealed class KeyboardGuideView : VisualElement
+    {
+        // 同じ動作に複数キーが割り当たっているものは併記する(RectorInput.inputactions と対応)
+        const string PanKey = "IJKL";
+        const string ZoomKey = "U/O";
+        const string ResetKey = "P";
+        const string LockKey = "TAB";
+        const string ParamKey = "SHIFT";
+        const string GrabKey = "CTRL";
+        const string FaceTopKey = "C";
+        const string FaceLeftKey = "F";
+        const string FaceRightKey = "X/ESC";
+        const string FaceBottomKey = "Z/SPACE";
+        const string MuteKey = "V";
+
+        // 差し替え接続はSubmitとの同時押し。併記のまま「SHIFT+Z/SPACE」にすると長すぎるので主キーだけ書く
+        const string ParamComboKey = ParamKey + "+Z";
+
+        readonly InputGuideChip lockChip;
+        readonly InputGuideChip paramChip;
+        readonly InputGuideChip grabChip;
+        readonly InputGuideChip faceTop;
+        readonly InputGuideChip faceLeft;
+        readonly InputGuideChip faceRight;
+        readonly InputGuideChip faceBottom;
+        readonly InputGuideChip muteChip;
+
+        public KeyboardGuideView()
+        {
+            AddToClassList(InputGuideClassNames.Keyboard);
+            pickingMode = PickingMode.Ignore;
+
+            // パン・ズーム・リセットはステートに依らず常に効くので、文言は作ったきり触らない
+            var viewRow = CreateRow();
+            viewRow.Add(new InputGuideChip(PanKey, "PAN"));
+            viewRow.Add(new InputGuideChip(ZoomKey, "ZOOM"));
+            viewRow.Add(new InputGuideChip(ResetKey, "RESET"));
+            Add(viewRow);
+
+            var modifierRow = CreateRow();
+            paramChip = new InputGuideChip(ParamKey);
+            grabChip = new InputGuideChip(GrabKey, "GRAB");
+            lockChip = new InputGuideChip(LockKey, "LOCK");
+            modifierRow.Add(paramChip);
+            modifierRow.Add(grabChip);
+            modifierRow.Add(lockChip);
+            Add(modifierRow);
+
+            var actionRow = CreateRow();
+            faceTop = new InputGuideChip(FaceTopKey);
+            faceLeft = new InputGuideChip(FaceLeftKey);
+            faceRight = new InputGuideChip(FaceRightKey);
+            faceBottom = new InputGuideChip(FaceBottomKey);
+            muteChip = new InputGuideChip(MuteKey, "MUTE");
+            actionRow.Add(faceTop);
+            actionRow.Add(faceLeft);
+            actionRow.Add(faceRight);
+            actionRow.Add(faceBottom);
+            actionRow.Add(muteChip);
+            Add(actionRow);
+        }
+
+        public void Apply(GuideContent content, bool grabHeld, bool lockHeld)
+        {
+            lockChip.SetState(true, lockHeld);
+            grabChip.SetState(content.Grab, grabHeld);
+            muteChip.SetState(content.Mute, false);
+
+            paramChip.SetKey(content.ParamCombo ? ParamComboKey : ParamKey);
+            paramChip.SetAction(content.Param ?? InputGuideContents.ParamLabel);
+            paramChip.SetState(content.Param != null, content.ParamActive);
+
+            SetFace(faceTop, content.FaceTop);
+            SetFace(faceLeft, content.FaceLeft);
+            SetFace(faceRight, content.FaceRight);
+            SetFace(faceBottom, content.FaceBottom);
+        }
+
+        /// <summary>空きポジションは「-」の減光表示にして、何も無いことを見せる。</summary>
+        static void SetFace(InputGuideChip chip, string text)
+        {
+            chip.SetAction(text);
+            chip.SetState(text != null, false);
+        }
+
+        static VisualElement CreateRow()
+        {
+            var row = new VisualElement { pickingMode = PickingMode.Ignore };
+            row.AddToClassList(InputGuideClassNames.Row);
+            return row;
+        }
+    }
+}

--- a/Assets/Rector/Scripts/UI/GraphPages/KeyboardGuideView.cs.meta
+++ b/Assets/Rector/Scripts/UI/GraphPages/KeyboardGuideView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 63b44bf128d1c43d8ad09e61a8a8b3b0

--- a/Assets/Rector/Scripts/UI/GraphPages/PadGuideView.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/PadGuideView.cs
@@ -1,0 +1,164 @@
+using UnityEngine.UIElements;
+
+namespace Rector.UI.GraphPages
+{
+    /// <summary>
+    /// ゲームパッド用の操作ガイド。中心軸を挟んだ2カラムの固定グリッドに、
+    /// ボタンの物理配置(L2/R2が上段、L1/R1が下段、△□○✕は菱形)を写す。
+    /// 左セルは右揃えで軸に吸着、右セルは左揃え。△と✕は右カラム先頭なので記号のxが揃う。
+    /// ステートで場所が動くと目で追えないので、構造と位置は常に固定のまま
+    /// 文言と有効/無効(減光)・ホールド中の反転だけを切り替える。
+    /// 空きボタンは「記号 -」で「何も無い」ことを見せる。
+    /// ボタン名はDualShock/Xboxを設定で選ぶ(<see cref="InputGuideMode"/>)。位置は同じで表記だけ変わる。
+    /// キーボード専用キーとスティック系(ズーム/パン/リセット)は載せない。
+    /// </summary>
+    public sealed class PadGuideView : VisualElement
+    {
+        /// <summary>
+        /// パッドごとのボタン名。位置(上/左/右/下、ショルダー4種)は共通で、呼び名だけが違う。
+        /// </summary>
+        readonly struct ButtonNames
+        {
+            public readonly string FaceTop;
+            public readonly string FaceLeft;
+            public readonly string FaceRight;
+            public readonly string FaceBottom;
+            public readonly string UpperLeft;
+            public readonly string UpperRight;
+            public readonly string LowerLeft;
+            public readonly string LowerRight;
+
+            /// <summary>下面4ボタンが記号か。記号ならそれ自体がボタンの形なので枠で囲まない。</summary>
+            public readonly bool FaceIsSymbol;
+
+            public ButtonNames(string faceTop, string faceLeft, string faceRight, string faceBottom,
+                string upperLeft, string upperRight, string lowerLeft, string lowerRight, bool faceIsSymbol)
+            {
+                FaceIsSymbol = faceIsSymbol;
+                FaceTop = faceTop;
+                FaceLeft = faceLeft;
+                FaceRight = faceRight;
+                FaceBottom = faceBottom;
+                UpperLeft = upperLeft;
+                UpperRight = upperRight;
+                LowerLeft = lowerLeft;
+                LowerRight = lowerRight;
+            }
+        }
+
+        // ◯はU+25CBだとJetBrains Monoにグリフが無く豆腐(□)になるので、U+25EFを使う。
+        // DualShockの下面は記号なので枠で囲まないが、Xboxは文字なので囲まないと動作名と混ざる
+        static readonly ButtonNames DualShockNames = new("△", "□", "◯", "✕", "L2", "R2", "L1", "R1", true);
+        static readonly ButtonNames XboxNames = new("Y", "X", "B", "A", "LT", "RT", "LB", "RB", false);
+
+        readonly InputGuideChip lockChip;
+        readonly InputGuideChip grabChip;
+        readonly InputGuideChip muteChip;
+        readonly InputGuideChip paramChip;
+        readonly InputGuideChip faceTop;
+        readonly InputGuideChip faceLeft;
+        readonly InputGuideChip faceRight;
+        readonly InputGuideChip faceBottom;
+
+        ButtonNames names = DualShockNames;
+
+        public PadGuideView()
+        {
+            AddToClassList(InputGuideClassNames.Pad);
+            pickingMode = PickingMode.Ignore;
+
+            // セルは透明な位置決め箱で、背景の塗りは文字ぴったりの内側チップにだけ載せる。
+            // ショルダーの動作名は固定なので、ここで入れたら以後はボタン名しか触らない
+            var lockCell = CreateCell(InputGuideClassNames.CellLeft, out lockChip, "LOCK");
+            var grabCell = CreateCell(InputGuideClassNames.CellRight, out grabChip, "GRAB");
+            var muteCell = CreateCell(InputGuideClassNames.CellLeft, out muteChip, "MUTE");
+            var paramCell = CreateCell(InputGuideClassNames.CellRight, out paramChip);
+            var faceTopCell = CreateCell(InputGuideClassNames.CellRight, out faceTop);
+            var faceLeftCell = CreateCell(InputGuideClassNames.CellLeft, out faceLeft);
+            var faceRightCell = CreateCell(InputGuideClassNames.CellRight, out faceRight);
+            var faceBottomCell = CreateCell(InputGuideClassNames.CellRight, out faceBottom);
+
+            // R側は△ボタンの右端あたりから始めて、L/R間に余白を作る
+            Add(CreateRow(lockCell, CreateShoulderGutter(), grabCell));
+            Add(CreateRow(muteCell, CreateShoulderGutter(), paramCell));
+
+            var gap = new VisualElement { pickingMode = PickingMode.Ignore };
+            gap.AddToClassList(InputGuideClassNames.Gap);
+            Add(gap);
+
+            // 菱形: △✕は中心軸の列、□は軸の左、○は軸から右へオフセット(パッドの形)
+            Add(CreateRow(CreateBlankCell(), faceTopCell));
+            var faceOffset = new VisualElement { pickingMode = PickingMode.Ignore };
+            faceOffset.AddToClassList(InputGuideClassNames.FaceOffset);
+            Add(CreateRow(faceLeftCell, faceOffset, faceRightCell));
+            Add(CreateRow(CreateBlankCell(), faceBottomCell));
+        }
+
+        public void SetXbox(bool xbox) => names = xbox ? XboxNames : DualShockNames;
+
+        public void Apply(GuideContent content, bool grabHeld, bool lockHeld)
+        {
+            SetFace(faceTop, names.FaceTop, content.FaceTop, names.FaceIsSymbol);
+            SetFace(faceLeft, names.FaceLeft, content.FaceLeft, names.FaceIsSymbol);
+            SetFace(faceRight, names.FaceRight, content.FaceRight, names.FaceIsSymbol);
+            SetFace(faceBottom, names.FaceBottom, content.FaceBottom, names.FaceIsSymbol);
+
+            lockChip.SetKey(names.UpperLeft);
+            lockChip.SetState(true, lockHeld);
+            grabChip.SetKey(names.UpperRight);
+            grabChip.SetState(content.Grab, grabHeld);
+            muteChip.SetKey(names.LowerLeft);
+            muteChip.SetState(content.Mute, false);
+            // 差し替え接続は下面ボタンとの同時押しなので、そのまま「R1+✕」と見せる
+            paramChip.SetKey(content.ParamCombo ? $"{names.LowerRight}+{names.FaceBottom}" : names.LowerRight);
+            paramChip.SetAction(content.Param ?? InputGuideContents.ParamLabel);
+            paramChip.SetState(content.Param != null, content.ParamActive);
+        }
+
+        /// <summary>空きポジションは「-」の減光表示にして、何も無いことを見せる。</summary>
+        static void SetFace(InputGuideChip chip, string button, string text, bool symbol)
+        {
+            chip.SetKey(button);
+            chip.SetKeyFramed(!symbol);
+            chip.SetAction(text);
+            chip.SetState(text != null, false);
+        }
+
+        static VisualElement CreateCell(string sideClassName, out InputGuideChip chip, string actionText = "")
+        {
+            var cell = new VisualElement { pickingMode = PickingMode.Ignore };
+            cell.AddToClassList(InputGuideClassNames.Cell);
+            cell.AddToClassList(sideClassName);
+
+            chip = new InputGuideChip(string.Empty, actionText);
+            cell.Add(chip);
+            return cell;
+        }
+
+        static VisualElement CreateBlankCell()
+        {
+            var cell = new VisualElement { pickingMode = PickingMode.Ignore };
+            cell.AddToClassList(InputGuideClassNames.Cell);
+            return cell;
+        }
+
+        static VisualElement CreateShoulderGutter()
+        {
+            var gutter = new VisualElement { pickingMode = PickingMode.Ignore };
+            gutter.AddToClassList(InputGuideClassNames.ShoulderGutter);
+            return gutter;
+        }
+
+        static VisualElement CreateRow(params VisualElement[] children)
+        {
+            var row = new VisualElement { pickingMode = PickingMode.Ignore };
+            row.AddToClassList(InputGuideClassNames.Row);
+            foreach (var child in children)
+            {
+                row.Add(child);
+            }
+
+            return row;
+        }
+    }
+}

--- a/Assets/Rector/Scripts/UI/GraphPages/PadGuideView.cs.meta
+++ b/Assets/Rector/Scripts/UI/GraphPages/PadGuideView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5214b32bac85e43abaa7b7ed93721581

--- a/Assets/Rector/Scripts/UI/Hud/GraphSettingsPageModel.cs
+++ b/Assets/Rector/Scripts/UI/Hud/GraphSettingsPageModel.cs
@@ -10,7 +10,7 @@ namespace Rector.UI.Hud
 {
     public sealed class GraphSettingsPageModel : IInitializable, IDisposable, ISettingsPageModel
     {
-        static readonly InputGuideMode[] GuideModes = { InputGuideMode.Off, InputGuideMode.DualShock, InputGuideMode.Xbox };
+        static readonly InputGuideMode[] GuideModes = { InputGuideMode.Off, InputGuideMode.DualShock, InputGuideMode.Xbox, InputGuideMode.Keyboard };
         static readonly string[] GuideOptions = GuideModes.Select(x => x.ToString()).ToArray();
 
         static readonly string[] GroupCountOptions = Enumerable

--- a/Assets/Rector/StaticResources/UI/StyleSheets/RectorStyles.uss
+++ b/Assets/Rector/StaticResources/UI/StyleSheets/RectorStyles.uss
@@ -356,19 +356,56 @@
     justify-content: flex-start;
 }
 
+/* チップは透明な入れ物で、塗りはキー名と動作がそれぞれ持つ */
 .rector-input-guide__chip {
+    flex-direction: row;
+    align-items: center;
     font-size: 10px;
     letter-spacing: 2px;
     /* Labelの既定margin(2px)を消さないと軸吸着が2pxずれる */
     margin: 0;
-    padding: 1px 6px;
     color: var(--rector-text-color);
+}
+
+/* 同じ色の下地を2つに割り、キー名だけ枠で囲む。押すものが四角として立つ。
+   動作側の透明な枠は、枠の有無で箱の高さがずれないようにするためのもの。
+   枠のぶんpaddingを1px詰めて、増える幅を隙間と枠だけに抑えている */
+.rector-input-guide__key,
+.rector-input-guide__action {
+    margin: 0;
+    padding: 0 5px;
+    border-width: 1px;
+    border-color: rgba(0, 0, 0, 0);
     background-color: var(--rector-text-background-color);
 }
 
-.rector-input-guide__chip--active {
+.rector-input-guide__key {
+    border-color: rgba(255, 255, 255, 0.25);
+}
+
+/* △□◯✕は記号そのものがボタンの形なので囲まない。枠は消しても幅が動かないよう色だけ透明にする */
+.rector-input-guide__key--plain {
+    border-color: rgba(0, 0, 0, 0);
+}
+
+.rector-input-guide__action {
+    margin-left: 2px;
+}
+
+.rector-input-guide__chip--active .rector-input-guide__key,
+.rector-input-guide__chip--active .rector-input-guide__action {
     color: white;
     background-color: black;
+}
+
+/* 反転すると下地が黒くなるので、枠を上げないと四角が消える */
+.rector-input-guide__chip--active .rector-input-guide__key {
+    border-color: rgba(255, 255, 255, 0.6);
+}
+
+/* 上の子孫セレクタの方が強いので、囲まない指定を反転時にも効かせ直す */
+.rector-input-guide__chip--active .rector-input-guide__key--plain {
+    border-color: rgba(0, 0, 0, 0);
 }
 
 .rector-input-guide__chip--disabled {
@@ -387,4 +424,26 @@
 /* ショルダーのR側は△ボタンの右端あたりから始める(L/R間の余白) */
 .rector-input-guide__shoulder-gutter {
     width: 36px;
+}
+
+/* パッド用とキーボード用は排他表示。縦積みは各レイアウト側が持つ */
+.rector-input-guide__pad,
+.rector-input-guide__keyboard {
+    flex-direction: column;
+}
+
+.rector-input-guide__pad {
+    align-items: flex-start;
+}
+
+/* キーボードは物理配置を写さず、意味でまとめた行にチップを横へ流す。
+   行の幅は文言で伸び縮みするので、右端で揃えてガイドの右辺だけは動かさない */
+.rector-input-guide__keyboard {
+    align-items: flex-end;
+}
+
+/* パッド版は透明セルが間隔を持つが、こちらはチップを直接並べるのでチップ側に持たせる。
+   縦は行がベタづきしないよう横より広く取る（行間は上下の合計で4px） */
+.rector-input-guide__keyboard .rector-input-guide__chip {
+    margin: 2px;
 }


### PR DESCRIPTION
Closes #86

## What

Adds a `Keyboard` mode to the HUD input guide. It swaps the whole layout rather than just the button labels, because copying the pad's diamond arrangement would say nothing about a keyboard.

```
IJKL PAN   U/O ZOOM   P RESET
SHIFT PARAM   CTRL GRAB   TAB LOCK
C ADD (DELETE)   F ACTION   X/ESC (CUT)   Z/SPACE SLOT   V MUTE
```

Three rows grouped by how the key is pressed: keys that move the view, keys held as modifiers, and single-press actions. Rows sit at one even spacing and are right-aligned, since their width follows the text.

## Notes on the content

- Pan / zoom / reset are listed because the pad guide omits them as stick input, and a keyboard has no stick.
- WASD is left out as self-evident. Q/E for group focus is left out because the binding does not currently work — worth a separate issue.
- Keys with more than one binding are shown together (`Z/SPACE`, `X/ESC`). The replace combo keeps only the primary key (`SHIFT+Z`) so the chip does not run long.

## Chip treatment (applies to the pad guide too)

Every chip now splits into two boxes on the same ground, with the key name framed at 0.25 white — below the text's 0.5, so it marks where the key is without becoming the loudest thing on screen. Inverted chips raise the frame to 0.6 so the box survives the black fill.

DualShock's `△□◯✕` skip the frame: a symbol already is the shape of a button. Xbox's `Y/X/B/A` keep it, being letters that would otherwise blend into the action names. The frame is dropped by turning its color transparent, so the layout does not shift.

## Structure

`InputGuideView` was one 287-line class holding the pad geometry, the button-name tables and the state→content table. It is now split into:

- `InputGuideContents` — the state→content table, shared by both layouts
- `InputGuideChip` — one guide entry (key box + action box), shared by both layouts
- `PadGuideView` — the existing diamond grid, moved as-is
- `KeyboardGuideView` — new
- `InputGuideView` — a thin container that switches on the setting

## Verification

Driven through the Unity CLI in play mode:

- All six `GraphPageState` values checked for text, dimming and inversion, including the `SHIFT+Z REPLACE` combo and the `-` empty slots
- Frame presence verified per mode: DualShock face buttons unframed, Xbox face buttons framed, shoulders framed in both
- Pad layout geometry unchanged
- Recompiles clean, console free of errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112RNESeRSJEspazF2vboVy