### PR TITLE
fix: make IJKL pan work, move grab to Option, drop Q/E group move (issue #98)

### DIFF
--- a/Assets/Rector/Scripts/RectorInput.cs
+++ b/Assets/Rector/Scripts/RectorInput.cs
@@ -105,16 +105,6 @@ namespace Rector
                     ""priority"": 0
                 },
                 {
-                    ""name"": ""MoveGroup"",
-                    ""type"": ""PassThrough"",
-                    ""id"": ""db45d00f-e29c-400f-8261-28f8b94c2f82"",
-                    ""expectedControlType"": ""Vector2"",
-                    ""processors"": """",
-                    ""interactions"": """",
-                    ""initialStateCheck"": true,
-                    ""priority"": 0
-                },
-                {
                     ""name"": ""Submit"",
                     ""type"": ""Button"",
                     ""id"": ""e5da0ab8-f142-45a2-bcb1-53b6cfbea470"",
@@ -246,7 +236,7 @@ namespace Rector
                 },
                 {
                     ""name"": ""Translate"",
-                    ""type"": ""PassThrough"",
+                    ""type"": ""Value"",
                     ""id"": ""c4b68e2c-330e-4f92-8821-dac33d4aaa91"",
                     ""expectedControlType"": ""Vector2"",
                     ""processors"": """",
@@ -555,7 +545,7 @@ namespace Rector
                 {
                     ""name"": """",
                     ""id"": ""46485fac-71ff-461e-a308-773847cfc799"",
-                    ""path"": ""<Keyboard>/ctrl"",
+                    ""path"": ""<Keyboard>/alt"",
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
@@ -722,7 +712,7 @@ namespace Rector
                     ""id"": ""98466bd1-b35b-478d-b65e-213845506d8b"",
                     ""path"": ""<Gamepad>/rightStick"",
                     ""interactions"": """",
-                    ""processors"": """",
+                    ""processors"": ""stickDeadzone"",
                     ""groups"": """",
                     ""action"": ""Translate"",
                     ""isComposite"": false,
@@ -804,39 +794,6 @@ namespace Rector
                     ""action"": ""ResetTransform"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
-                },
-                {
-                    ""name"": ""Keyboard"",
-                    ""id"": ""8f134aaa-17c4-4571-9d16-7ad1fa8a2f1a"",
-                    ""path"": ""2DVector(mode=1)"",
-                    ""interactions"": """",
-                    ""processors"": """",
-                    ""groups"": """",
-                    ""action"": ""MoveGroup"",
-                    ""isComposite"": true,
-                    ""isPartOfComposite"": false
-                },
-                {
-                    ""name"": ""left"",
-                    ""id"": ""18ab6b63-cd7f-4769-98f8-acebbf5b7ca5"",
-                    ""path"": ""<Keyboard>/q"",
-                    ""interactions"": """",
-                    ""processors"": """",
-                    ""groups"": ""Keyboard&Mouse"",
-                    ""action"": ""MoveGroup"",
-                    ""isComposite"": false,
-                    ""isPartOfComposite"": true
-                },
-                {
-                    ""name"": ""right"",
-                    ""id"": ""48cb8ca2-271b-46a4-80b4-146bed62a3e6"",
-                    ""path"": ""<Keyboard>/e"",
-                    ""interactions"": """",
-                    ""processors"": """",
-                    ""groups"": ""Keyboard&Mouse"",
-                    ""action"": ""MoveGroup"",
-                    ""isComposite"": false,
-                    ""isPartOfComposite"": true
                 }
             ]
         },
@@ -1220,7 +1177,6 @@ namespace Rector
             // Graph
             m_Graph = asset.FindActionMap("Graph", throwIfNotFound: true);
             m_Graph_Navigate = m_Graph.FindAction("Navigate", throwIfNotFound: true);
-            m_Graph_MoveGroup = m_Graph.FindAction("MoveGroup", throwIfNotFound: true);
             m_Graph_Submit = m_Graph.FindAction("Submit", throwIfNotFound: true);
             m_Graph_Cancel = m_Graph.FindAction("Cancel", throwIfNotFound: true);
             m_Graph_Action = m_Graph.FindAction("Action", throwIfNotFound: true);
@@ -1328,7 +1284,6 @@ namespace Rector
         private readonly InputActionMap m_Graph;
         private List<IGraphActions> m_GraphActionsCallbackInterfaces = new List<IGraphActions>();
         private readonly InputAction m_Graph_Navigate;
-        private readonly InputAction m_Graph_MoveGroup;
         private readonly InputAction m_Graph_Submit;
         private readonly InputAction m_Graph_Cancel;
         private readonly InputAction m_Graph_Action;
@@ -1359,10 +1314,6 @@ namespace Rector
             /// Provides access to the underlying input action "Graph/Navigate".
             /// </summary>
             public InputAction @Navigate => m_Wrapper.m_Graph_Navigate;
-            /// <summary>
-            /// Provides access to the underlying input action "Graph/MoveGroup".
-            /// </summary>
-            public InputAction @MoveGroup => m_Wrapper.m_Graph_MoveGroup;
             /// <summary>
             /// Provides access to the underlying input action "Graph/Submit".
             /// </summary>
@@ -1452,9 +1403,6 @@ namespace Rector
                 @Navigate.started += instance.OnNavigate;
                 @Navigate.performed += instance.OnNavigate;
                 @Navigate.canceled += instance.OnNavigate;
-                @MoveGroup.started += instance.OnMoveGroup;
-                @MoveGroup.performed += instance.OnMoveGroup;
-                @MoveGroup.canceled += instance.OnMoveGroup;
                 @Submit.started += instance.OnSubmit;
                 @Submit.performed += instance.OnSubmit;
                 @Submit.canceled += instance.OnSubmit;
@@ -1514,9 +1462,6 @@ namespace Rector
                 @Navigate.started -= instance.OnNavigate;
                 @Navigate.performed -= instance.OnNavigate;
                 @Navigate.canceled -= instance.OnNavigate;
-                @MoveGroup.started -= instance.OnMoveGroup;
-                @MoveGroup.performed -= instance.OnMoveGroup;
-                @MoveGroup.canceled -= instance.OnMoveGroup;
                 @Submit.started -= instance.OnSubmit;
                 @Submit.performed -= instance.OnSubmit;
                 @Submit.canceled -= instance.OnSubmit;
@@ -1782,13 +1727,6 @@ namespace Rector
             /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
             /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
             void OnNavigate(InputAction.CallbackContext context);
-            /// <summary>
-            /// Method invoked when associated input action "MoveGroup" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
-            /// </summary>
-            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
-            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
-            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
-            void OnMoveGroup(InputAction.CallbackContext context);
             /// <summary>
             /// Method invoked when associated input action "Submit" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
             /// </summary>

--- a/Assets/Rector/Scripts/UI/GraphPages/GraphInputAction.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/GraphInputAction.cs
@@ -30,7 +30,6 @@ namespace Rector.UI.GraphPages
         readonly Subject<Unit> openSystem = new();
         readonly Subject<Unit> openScene = new();
         readonly Subject<Unit> resetTransform = new();
-        readonly Subject<int> moveGroup = new();
         readonly Subject<int> moveNodeToGroup = new();
 
         readonly NavigateInputThrottle navigateInputThrottle = new();
@@ -52,7 +51,6 @@ namespace Rector.UI.GraphPages
         public Observable<Unit> OpenScene => openScene;
         public Observable<Unit> ResetTransform => resetTransform;
         public Observable<Vector2> Navigate => navigateInputThrottle.Navigate;
-        public Observable<int> MoveGroup => moveGroup;
         public Observable<int> MoveNodeToGroup => moveNodeToGroup;
 
         public Vector2 Translate { get; private set; }
@@ -60,7 +58,6 @@ namespace Rector.UI.GraphPages
         public bool IsNodeParameterOpen => rectorInput.Graph.OpenNodeParameter.IsPressed();
 
         const float DirectionThreshold = 0.5f;
-        int moveGroupDirection;
 
         enum NavigateDirection
         {
@@ -96,9 +93,6 @@ namespace Rector.UI.GraphPages
         {
             Translate = Vector2.zero;
             Zoom = 0f;
-            // moveGroupDirection はここでリセットしない。MoveGroup は initialStateCheck 付きなので、
-            // 倒したまま抜けて戻ると再有効化時に performed が来る。0に戻しておくと
-            // 「中立から倒れた」と誤判定して、触っていないのにグループが1つ飛ぶ。
             rectorInput.Graph.Disable();
         }
 
@@ -126,7 +120,7 @@ namespace Rector.UI.GraphPages
         }
 
         /// <remarks>
-        /// GrabModifier(R2/Ctrl)を押している間は十字キーを別コマンドとして扱う。
+        /// GrabModifier(R2/Option)を押している間は十字キーを別コマンドとして扱う。
         /// 左右は選択ノードのグループ移動。離散的な操作なのでリピートさせず、
         /// 方向が新しく確定した瞬間だけ発火させる。
         /// </remarks>
@@ -176,30 +170,6 @@ namespace Rector.UI.GraphPages
             }
 
             return value.y > 0 ? NavigateDirection.Up : NavigateDirection.Down;
-        }
-
-        /// <remarks>
-        /// グループ移動は離散的な操作なので、Navigateのようなリピートはさせない。
-        /// スティックが中立から左右に倒れた瞬間だけ発火させる。
-        /// </remarks>
-        public void OnMoveGroup(InputAction.CallbackContext context)
-        {
-            var direction = context.canceled ? 0 : ToHorizontalDirection(context.ReadValue<Vector2>());
-            if (direction == moveGroupDirection) return;
-
-            moveGroupDirection = direction;
-            if (direction != 0)
-            {
-                moveGroup.OnNext(direction);
-            }
-        }
-
-        static int ToHorizontalDirection(Vector2 value)
-        {
-            // 縦入力と、倒しきっていない入力は無視する
-            if (Mathf.Abs(value.x) < DirectionThreshold) return 0;
-            if (Mathf.Abs(value.x) <= Mathf.Abs(value.y)) return 0;
-            return value.x > 0 ? 1 : -1;
         }
 
         public void OnSubmit(InputAction.CallbackContext context)

--- a/Assets/Rector/Scripts/UI/GraphPages/GraphPage.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/GraphPage.cs
@@ -150,7 +150,6 @@ namespace Rector.UI.GraphPages
             Groups.Count.Subscribe(_ => Sort()).AddTo(disposable);
 
             graphInputAction.Navigate.Subscribe(x => CurrentInputHandler.Navigate(x)).AddTo(disposable);
-            graphInputAction.MoveGroup.Subscribe(x => CurrentInputHandler.MoveGroup(x)).AddTo(disposable);
             graphInputAction.MoveNodeToGroup.Subscribe(x => CurrentInputHandler.MoveNodeToGroup(x)).AddTo(disposable);
             graphInputAction.Submit.Subscribe(_ => CurrentInputHandler.Submit()).AddTo(disposable);
             graphInputAction.Cancel.Subscribe(_ => CurrentInputHandler.Cancel()).AddTo(disposable);
@@ -190,21 +189,6 @@ namespace Rector.UI.GraphPages
         {
             Graph.AddNode(nodeView, SelectedNode?.Group ?? 0);
             Sort();
-        }
-
-        /// <summary>
-        /// フォーカスを隣のグループへ移す。directionは-1か1。
-        /// </summary>
-        /// <remarks>
-        /// ノードのないグループは飛ばし、端まで行ったらループする。
-        /// </remarks>
-        public void MoveActiveGroup(int direction)
-        {
-            var next = nodeNavigator.FindNodeInAdjacentGroup(SelectedNode, direction, Groups.CurrentCount);
-            if (next != null)
-            {
-                SelectNode(next);
-            }
         }
 
         /// <summary>

--- a/Assets/Rector/Scripts/UI/GraphPages/GraphPageInputHandler.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/GraphPageInputHandler.cs
@@ -9,19 +9,7 @@ namespace Rector.UI.GraphPages
         }
 
         /// <summary>
-        /// フォーカスを隣のグループへ移す。directionは-1か1。キーボードQ/E。
-        /// </summary>
-        /// <remarks>
-        /// ノード自体のグループ移動は <see cref="MoveNodeToGroup"/>(GrabModifier側)が持つ。
-        /// 同じ操作がStateによって別の意味にならないよう、ここで移すのはフォーカスだけにする。
-        /// 実装しないStateでは何もしない。
-        /// </remarks>
-        public virtual void MoveGroup(int direction)
-        {
-        }
-
-        /// <summary>
-        /// 選択中のノードを隣のグループへ移す。directionは-1か1。GrabModifier(R2/Ctrl)を押しながらの左右。
+        /// 選択中のノードを隣のグループへ移す。directionは-1か1。GrabModifier(R2/Option)を押しながらの左右。
         /// </summary>
         public virtual void MoveNodeToGroup(int direction)
         {

--- a/Assets/Rector/Scripts/UI/GraphPages/KeyboardGuideView.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/KeyboardGuideView.cs
@@ -23,7 +23,7 @@ namespace Rector.UI.GraphPages
         const string ResetKey = "P";
         const string LockKey = "TAB";
         const string ParamKey = "SHIFT";
-        const string GrabKey = "CTRL";
+        const string GrabKey = "OPTION";
         const string FaceTopKey = "C";
         const string FaceLeftKey = "F";
         const string FaceRightKey = "X/ESC";

--- a/Assets/Rector/Scripts/UI/GraphPages/NodeSelectionInputHandler.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/NodeSelectionInputHandler.cs
@@ -34,11 +34,6 @@ namespace Rector.UI.GraphPages
             }
         }
 
-        public override void MoveGroup(int direction)
-        {
-            graphPage.MoveActiveGroup(direction);
-        }
-
         public override void MoveNodeToGroup(int direction)
         {
             graphPage.MoveSelectedNodeToGroup(direction);

--- a/Assets/Rector/Scripts/UI/GraphPages/TargetNodeSelectionInputHandler.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/TargetNodeSelectionInputHandler.cs
@@ -25,16 +25,6 @@ namespace Rector.UI.GraphPages
             }
         }
 
-        public override void MoveGroup(int direction)
-        {
-            // MoveActiveGroupはSelectedNode(ソース)を動かしてしまうので、ターゲット用の別経路
-            var next = navigator.FindNodeInAdjacentGroup(graphPage.TargetNode, direction, graphPage.Groups.CurrentCount);
-            if (next != null)
-            {
-                graphPage.SetTargetNode(next);
-            }
-        }
-
         public override void AddNode()
         {
             graphPage.PromoteTargetToSource();

--- a/Assets/Rector/Settings/RectorInput.inputactions
+++ b/Assets/Rector/Settings/RectorInput.inputactions
@@ -15,15 +15,6 @@
                     "initialStateCheck": true
                 },
                 {
-                    "name": "MoveGroup",
-                    "type": "PassThrough",
-                    "id": "db45d00f-e29c-400f-8261-28f8b94c2f82",
-                    "expectedControlType": "Vector2",
-                    "processors": "",
-                    "interactions": "",
-                    "initialStateCheck": true
-                },
-                {
                     "name": "Submit",
                     "type": "Button",
                     "id": "e5da0ab8-f142-45a2-bcb1-53b6cfbea470",
@@ -142,7 +133,7 @@
                 },
                 {
                     "name": "Translate",
-                    "type": "PassThrough",
+                    "type": "Value",
                     "id": "c4b68e2c-330e-4f92-8821-dac33d4aaa91",
                     "expectedControlType": "Vector2",
                     "processors": "",
@@ -449,7 +440,7 @@
                 {
                     "name": "",
                     "id": "46485fac-71ff-461e-a308-773847cfc799",
-                    "path": "<Keyboard>/ctrl",
+                    "path": "<Keyboard>/alt",
                     "interactions": "",
                     "processors": "",
                     "groups": "",
@@ -616,7 +607,7 @@
                     "id": "98466bd1-b35b-478d-b65e-213845506d8b",
                     "path": "<Gamepad>/rightStick",
                     "interactions": "",
-                    "processors": "",
+                    "processors": "stickDeadzone",
                     "groups": "",
                     "action": "Translate",
                     "isComposite": false,
@@ -698,39 +689,6 @@
                     "action": "ResetTransform",
                     "isComposite": false,
                     "isPartOfComposite": false
-                },
-                {
-                    "name": "Keyboard",
-                    "id": "8f134aaa-17c4-4571-9d16-7ad1fa8a2f1a",
-                    "path": "2DVector(mode=1)",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "",
-                    "action": "MoveGroup",
-                    "isComposite": true,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "left",
-                    "id": "18ab6b63-cd7f-4769-98f8-acebbf5b7ca5",
-                    "path": "<Keyboard>/q",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "Keyboard&Mouse",
-                    "action": "MoveGroup",
-                    "isComposite": false,
-                    "isPartOfComposite": true
-                },
-                {
-                    "name": "right",
-                    "id": "48cb8ca2-271b-46a4-80b4-146bed62a3e6",
-                    "path": "<Keyboard>/e",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "Keyboard&Mouse",
-                    "action": "MoveGroup",
-                    "isComposite": false,
-                    "isPartOfComposite": true
                 }
             ]
         },


### PR DESCRIPTION
Closes #98

Three input problems, one per change.

## IJKL did nothing when a gamepad was connected

`Translate` was the only action typed `PassThrough` — `Zoom` is `Value`. PassThrough forwards every binding's value change as-is, so the gamepad's right stick (which reports zero while centred, and had no `stickDeadzone` processor) overwrote whatever the keyboard composite had just written, every frame.

Typing it `Value` restores disambiguation, which picks the most-actuated control and so lets the keyboard win while a key is held. The stick also gains `stickDeadzone` so a drifting one cannot nudge the view.

**Confirmed both ways** against a virtual pad driven from the Unity CLI:

| `Translate` type | pad connected, press `I` |
| --- | --- |
| `PassThrough` (before) | `Translate=(0,0)` |
| `Value` (after) | `Translate=(0,1)` |

All four keys check out after the fix: `I`→`(0,1)`, `K`→`(0,-1)`, `J`→`(-1,0)`, `L`→`(1,0)`.

## Grab moves from Ctrl to Option

macOS claims `Ctrl + ←→` for switching spaces, so the chord that moves a node between groups never reached the app. `GrabModifier` now binds `<Keyboard>/alt`, and the keyboard guide reads `OPTION GRAB`.

Verified: `alt` down sets `GrabModifierHeld`, `alt + →` fires `MoveNodeToGroup(+1)`.

## Q/E group focus is removed

As the issue allows. Nothing is lost — the ordinary left/right navigation already hops into the neighbouring group once it reaches the edge of the current one (`NodeNavigator.SelectNextNode`), which is what the gamepad has always used. That is also why the wiki listed "十字キーの左右" in the gamepad column for this row.

Removes the `MoveGroup` action along with its subject, handler overrides and `GraphPage.MoveActiveGroup`. `NodeNavigator.FindNodeInAdjacentGroup` stays, since the ordinary navigation depends on it.

## Docs

The wiki's 操作方法 page is updated in the same pass: `Ctrl + 左右` → `Option + 左右`, the Q/E row rewritten, and — picking up a leftover from #86 — `Keyboard` added to the HUD Guide options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112RNESeRSJEspazF2vboVy