### PR TITLE
fix: make OSC logs minimal (issue #104)

### DIFF
--- a/Assets/Rector/Scripts/RectorLogger.cs
+++ b/Assets/Rector/Scripts/RectorLogger.cs
@@ -67,22 +67,24 @@ namespace Rector
             var targets = localAddresses.Length > 0
                 ? string.Join(", ", localAddresses.Select(a => $"{a}:{port}"))
                 : $"127.0.0.1:{port}";
-            LogInternal($"[SYSTEM/OSC] listening on port {port}. Send to {targets}");
+            LogInternal($"[SYSTEM/OSC] {targets}");
         }
 
         public static void OscDisabled()
         {
-            LogInternal("[SYSTEM/OSC] input is off. Enable it in System > OSC Settings.");
+            LogInternal("[SYSTEM/OSC] off");
         }
 
+        // 設定ページの "port N unavailable" と同じ言い方にする。落ちる理由はほぼ
+        // ポートの取り合いだが、それ以外のソケットエラーの手掛かりを括弧に残す
         public static void OscBindFailed(int port, string message)
         {
-            LogInternal($"[SYSTEM/OSC] failed to listen on port {port}. {message}");
+            LogInternal($"[SYSTEM/OSC] port {port} unavailable ({message})");
         }
 
         public static void OscInputOverflow()
         {
-            LogInternal("[SYSTEM/OSC] dropped incoming messages. The receive queue overflowed.");
+            LogInternal("[SYSTEM/OSC] input dropped (queue overflow)");
         }
 
         public static void DisableStackTrace()


### PR DESCRIPTION
Closes #104

## Problem

The OSC log lines were written as prose and repeated the port number, pushing
the address — the part that matters when pointing a phone or iPad at Rector —
to the right of the log column.

## Change

Match the sibling system logs (`[SYSTEM/AUDIO]`, `[SYSTEM/DISPLAY]`), which
print only the tag and the value:

| | before | after |
|---|---|---|
| listening | `listening on port 9000. Send to 192.168.1.5:9000` | `192.168.1.5:9000, 10.0.0.3:9000` |
| disabled | `input is off. Enable it in System > OSC Settings.` | `off` |
| bind failed | `failed to listen on port 9000. {message}` | `port 9000 unavailable ({message})` |
| overflow | `dropped incoming messages. The receive queue overflowed.` | `input dropped (queue overflow)` |

Only the four string literals in `RectorLogger` changed; the method signatures
and the four call sites in `OscModel` are untouched.

Notes on the two judgement calls:

- All local addresses are still listed. `OscSettingsPageModel.BuildAddressText`
  folds anything past the first two into `+N` and its comment points at this log
  for the full list, so narrowing the log would break that.
- The bind failure keeps the socket message in parentheses, for failures other
  than a port conflict. `port N unavailable` matches the wording the OSC
  settings page already uses.

## Verification

- Compile-checked with the Unity-bundled Roslyn (this branch is in a git
  worktree with no `Library/`, so `unity command recompile` would have read the
  main checkout): no `error CS`, and the emitted assembly contains the new
  strings with the old ones gone.
- `dotnet format Rector.csproj --include Assets/Rector/Scripts/RectorLogger.cs`
  reported no changes.
- The HUD was not opened; the change only rewrites the format strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)