### PR TITLE
add: light up every guide chip while its button is held (issue #100)

### DIFF
--- a/Assets/Rector/Scripts/UI/GraphPages/GraphInputAction.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/GraphInputAction.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Cysharp.Threading.Tasks;
 using R3;
 using UnityEngine;
@@ -44,7 +45,6 @@ namespace Rector.UI.GraphPages
         public Observable<Unit> LockStarted => lockStarted;
         public Observable<Unit> LockEnded => lockEnded;
         public ReadOnlyReactiveProperty<bool> GrabModifierHeld => grabModifierHeld;
-        public ReadOnlyReactiveProperty<bool> LockHeld => lockHeld;
         public Observable<Unit> OpenNodeParameter => openNodeParameter;
         public Observable<Unit> CloseNodeParameter => closeNodeParameter;
         public Observable<Unit> OpenSystem => openSystem;
@@ -70,7 +70,26 @@ namespace Rector.UI.GraphPages
 
         // ガイドバー等が購読できるようReactivePropertyで持つ
         readonly ReactiveProperty<bool> grabModifierHeld = new(false);
-        readonly ReactiveProperty<bool> lockHeld = new(false);
+
+        /// <summary>
+        /// 操作ガイドを光らせるための押下状態。位置ごとに1つ持つ。
+        /// </summary>
+        /// <remarks>
+        /// phaseの意味がinteractionで変わるので、押下の取り方は位置ごとに選んでいる。
+        /// interaction無しとHoldは started(押す)/canceled(離す) が揃うが、
+        /// **Tapは離したときperformedで終わり canceled が来ない**。
+        /// Tapが付いた Cancel / AddNode は同じ物理ボタンにHoldのアクション
+        /// (RemoveEdge / RemoveNode)が同居していてバインディングも一致しているので、
+        /// そちらを押下の代表として見る。バインディングを分けるときはここも直すこと。
+        /// </remarks>
+        readonly ReactiveProperty<bool>[] pressed =
+            Enumerable.Range(0, Enum.GetValues(typeof(GuideInput)).Length)
+                .Select(_ => new ReactiveProperty<bool>(false))
+                .ToArray();
+
+        public ReadOnlyReactiveProperty<bool> Pressed(GuideInput input) => pressed[(int)input];
+
+        void SetPressed(GuideInput input, bool value) => pressed[(int)input].Value = value;
         NavigateDirection chordNavigateDirection;
         bool chordNeutralRequired;
 
@@ -174,12 +193,15 @@ namespace Rector.UI.GraphPages
 
         public void OnSubmit(InputAction.CallbackContext context)
         {
+            UpdatePressed(GuideInput.FaceBottom, context);
             if (context.performed)
             {
                 submit.OnNext(Unit.Default);
             }
         }
 
+        // Cancel / AddNode はTapなので押下の追跡には使わない(pressedのremarks参照)。
+        // 同じボタンの RemoveEdge / RemoveNode が代わりに光らせる。
         public void OnCancel(InputAction.CallbackContext context)
         {
             if (context.performed)
@@ -190,6 +212,7 @@ namespace Rector.UI.GraphPages
 
         public void OnAction(InputAction.CallbackContext context)
         {
+            UpdatePressed(GuideInput.FaceLeft, context);
             if (context.performed)
             {
                 action.OnNext(Unit.Default);
@@ -204,8 +227,29 @@ namespace Rector.UI.GraphPages
             }
         }
 
+        /// <summary>started で点け、canceled で消す。</summary>
+        /// <remarks>
+        /// 使えるのはデジタルなボタンだけ。startedは actuation > 0 で飛ぶのに対し
+        /// performed は押し込み閾値(既定0.5)を超えないと飛ばないので、アナログトリガー
+        /// (L2/R2にあたる Lock / GrabModifier)でこれを使うと、機能が動いていない半押し域で
+        /// ガイドだけが光ってしまう。あの2つは performed / canceled で拾っている。
+        /// Tapのアクション(Cancel / AddNode)も canceled が来ないので使えない(pressedのremarks参照)。
+        /// </remarks>
+        void UpdatePressed(GuideInput input, InputAction.CallbackContext context)
+        {
+            if (context.started)
+            {
+                SetPressed(input, true);
+            }
+            else if (context.canceled)
+            {
+                SetPressed(input, false);
+            }
+        }
+
         public void OnRemoveEdge(InputAction.CallbackContext context)
         {
+            UpdatePressed(GuideInput.FaceRight, context);
             if (context.started)
             {
                 removeEdgeHoldId = (removeEdgeHoldId + 1) % 255;
@@ -239,6 +283,7 @@ namespace Rector.UI.GraphPages
 
         public void OnRemoveNode(InputAction.CallbackContext context)
         {
+            UpdatePressed(GuideInput.FaceTop, context);
             if (context.started)
             {
                 removeNodeHoldId = (removeNodeHoldId + 1) % 255;
@@ -280,11 +325,15 @@ namespace Rector.UI.GraphPages
         {
             if (context.performed)
             {
+                // L2/R2はアナログトリガーなので、startedを使うと半押しで光ってしまう
+                // (詳細は UpdatePressed のコメント)
+                SetPressed(GuideInput.UpperRight, true);
                 grabModifierHeld.Value = true;
                 BeginChord();
             }
             else if (context.canceled)
             {
+                SetPressed(GuideInput.UpperRight, false);
                 // 離した時点で倒れたままの十字キーはナビゲートに引き継がない。
                 // Navigateは値が変わるまでイベントが来ないので、倒し直すまで移動しない。
                 grabModifierHeld.Value = false;
@@ -305,6 +354,7 @@ namespace Rector.UI.GraphPages
         /// <remarks>L1/Vの単押しトグル。</remarks>
         public void OnMute(InputAction.CallbackContext context)
         {
+            UpdatePressed(GuideInput.LowerLeft, context);
             if (context.performed)
             {
                 mute.OnNext(Unit.Default);
@@ -313,6 +363,7 @@ namespace Rector.UI.GraphPages
 
         public void OnOpenNodeParameter(InputAction.CallbackContext context)
         {
+            UpdatePressed(GuideInput.LowerRight, context);
             if (context.performed)
             {
                 openNodeParameter.OnNext(Unit.Default);
@@ -327,12 +378,12 @@ namespace Rector.UI.GraphPages
         {
             if (context.performed)
             {
-                lockHeld.Value = true;
+                SetPressed(GuideInput.UpperLeft, true);
                 lockStarted.OnNext(Unit.Default);
             }
             else if (context.canceled)
             {
-                lockHeld.Value = false;
+                SetPressed(GuideInput.UpperLeft, false);
                 lockEnded.OnNext(Unit.Default);
             }
         }
@@ -363,6 +414,9 @@ namespace Rector.UI.GraphPages
             {
                 Zoom = 0f;
             }
+
+            // Value型なので倒している間ずっと値が来る。押下は値の有無で決まる
+            SetPressed(GuideInput.Zoom, !Mathf.Approximately(Zoom, 0f));
         }
 
         public void OnTranslate(InputAction.CallbackContext context)
@@ -375,10 +429,13 @@ namespace Rector.UI.GraphPages
             {
                 Translate = Vector2.zero;
             }
+
+            SetPressed(GuideInput.Pan, Translate.sqrMagnitude != 0f);
         }
 
         public void OnResetTransform(InputAction.CallbackContext context)
         {
+            UpdatePressed(GuideInput.Reset, context);
             if (context.performed)
             {
                 resetTransform.OnNext(Unit.Default);

--- a/Assets/Rector/Scripts/UI/GraphPages/GraphPage.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/GraphPage.cs
@@ -173,7 +173,7 @@ namespace Rector.UI.GraphPages
 
             holdGuideView.Bind(holdGuideModel).AddTo(disposable);
             nodeParameterView.Bind(nodeParameterModel).AddTo(disposable);
-            inputGuideView.Bind(State, graphInputAction.GrabModifierHeld, graphInputAction.LockHeld, GuideSettings.Mode).AddTo(disposable);
+            inputGuideView.Bind(State, graphInputAction, GuideSettings.Mode).AddTo(disposable);
 
             // SortでNodeViewのWidthを使用するので1F待機する
             Observable.EveryUpdate(UnityFrameProvider.PostLateUpdate)

--- a/Assets/Rector/Scripts/UI/GraphPages/GuideInput.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/GuideInput.cs
@@ -1,0 +1,23 @@
+namespace Rector.UI.GraphPages
+{
+    /// <summary>
+    /// 操作ガイドの押下表示が対応する「位置」。どのアクションを見るかは
+    /// <see cref="GraphInputAction"/> 側に閉じ込める(パッドとキーボードで同じ位置を指す)。
+    /// </summary>
+    public enum GuideInput
+    {
+        FaceTop,
+        FaceLeft,
+        FaceRight,
+        FaceBottom,
+        UpperLeft,
+        UpperRight,
+        LowerLeft,
+        LowerRight,
+
+        // 以下はキーボードのガイドにしか出ない(パッドはスティック)
+        Pan,
+        Zoom,
+        Reset,
+    }
+}

--- a/Assets/Rector/Scripts/UI/GraphPages/GuideInput.cs.meta
+++ b/Assets/Rector/Scripts/UI/GraphPages/GuideInput.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ff594626cd9de489991c334a3aa67a00

--- a/Assets/Rector/Scripts/UI/GraphPages/InputGuideChip.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/InputGuideChip.cs
@@ -12,6 +12,10 @@ namespace Rector.UI.GraphPages
         readonly Label key;
         readonly Label action;
 
+        bool enabled = true;
+        bool stateActive;
+        bool pressed;
+
         public InputGuideChip(string keyText = "", string actionText = "")
         {
             AddToClassList(InputGuideClassNames.Chip);
@@ -38,8 +42,22 @@ namespace Rector.UI.GraphPages
 
         public void SetState(bool enabled, bool active)
         {
+            this.enabled = enabled;
+            stateActive = active;
+            Refresh();
+        }
+
+        /// <summary>そのボタンを押している間。ステート由来の反転とは別に持ってORで解決する。</summary>
+        public void SetPressed(bool value)
+        {
+            pressed = value;
+            Refresh();
+        }
+
+        void Refresh()
+        {
             EnableInClassList(InputGuideClassNames.ChipDisabled, !enabled);
-            EnableInClassList(InputGuideClassNames.ChipActive, enabled && active);
+            EnableInClassList(InputGuideClassNames.ChipActive, enabled && (stateActive || pressed));
         }
     }
 }

--- a/Assets/Rector/Scripts/UI/GraphPages/InputGuideView.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/InputGuideView.cs
@@ -9,15 +9,17 @@ namespace Rector.UI.GraphPages
     /// パッド用(<see cref="PadGuideView"/>)とキーボード用(<see cref="KeyboardGuideView"/>)を
     /// 両方持って設定(<see cref="InputGuideMode"/>)で表示を切り替える。
     /// 中身は <see cref="InputGuideContents"/> の1つの表を両方が読む。
+    /// 押しているボタンはチップの反転で見せる。押下は
+    /// <see cref="GraphInputAction.Pressed"/> を位置ごとに購読して受け取る。
     /// </summary>
     public sealed class InputGuideView : VisualElement
     {
+        static readonly GuideInput[] Inputs = (GuideInput[])Enum.GetValues(typeof(GuideInput));
+
         readonly PadGuideView padView = new();
         readonly KeyboardGuideView keyboardView = new();
 
         GraphPageState currentState;
-        bool grabHeld;
-        bool lockHeld;
 
         public InputGuideView()
         {
@@ -31,47 +33,48 @@ namespace Rector.UI.GraphPages
 
         public IDisposable Bind(
             ReadOnlyReactiveProperty<GraphPageState> state,
-            ReadOnlyReactiveProperty<bool> grabModifierHeld,
-            ReadOnlyReactiveProperty<bool> lockHeldProperty,
+            GraphInputAction input,
             ReadOnlyReactiveProperty<InputGuideMode> mode)
         {
-            return new CompositeDisposable(
-                state.Subscribe(x =>
-                {
-                    currentState = x;
-                    UpdateContent();
-                }),
-                grabModifierHeld.Subscribe(x =>
-                {
-                    grabHeld = x;
-                    UpdateContent();
-                }),
-                lockHeldProperty.Subscribe(x =>
-                {
-                    lockHeld = x;
-                    UpdateContent();
-                }),
-                mode.Subscribe(x =>
-                {
-                    style.display = x == InputGuideMode.Off ? DisplayStyle.None : DisplayStyle.Flex;
+            var disposables = new CompositeDisposable();
 
-                    var keyboard = x == InputGuideMode.Keyboard;
-                    padView.style.display = keyboard ? DisplayStyle.None : DisplayStyle.Flex;
-                    keyboardView.style.display = keyboard ? DisplayStyle.Flex : DisplayStyle.None;
-                    padView.SetXbox(x == InputGuideMode.Xbox);
+            state.Subscribe(x =>
+            {
+                currentState = x;
+                UpdateContent();
+            }).AddTo(disposables);
 
-                    UpdateContent();
-                })
-            );
+            mode.Subscribe(x =>
+            {
+                style.display = x == InputGuideMode.Off ? DisplayStyle.None : DisplayStyle.Flex;
+
+                var keyboard = x == InputGuideMode.Keyboard;
+                padView.style.display = keyboard ? DisplayStyle.None : DisplayStyle.Flex;
+                keyboardView.style.display = keyboard ? DisplayStyle.Flex : DisplayStyle.None;
+                padView.SetXbox(x == InputGuideMode.Xbox);
+
+                UpdateContent();
+            }).AddTo(disposables);
+
+            // 隠れている方にも流す。切り替え時に古い反転が残る分岐を持たない方が安い
+            foreach (var guideInput in Inputs)
+            {
+                var captured = guideInput;
+                input.Pressed(captured).Subscribe(pressed =>
+                {
+                    padView.SetPressed(captured, pressed);
+                    keyboardView.SetPressed(captured, pressed);
+                }).AddTo(disposables);
+            }
+
+            return disposables;
         }
 
-        // 隠れている方も一緒に更新する。ラベル代入が十数個増えるだけで、
-        // 切り替え時に古い表示が残る分岐を持たない方が安い。
         void UpdateContent()
         {
             var content = InputGuideContents.Get(currentState);
-            padView.Apply(content, grabHeld, lockHeld);
-            keyboardView.Apply(content, grabHeld, lockHeld);
+            padView.Apply(content);
+            keyboardView.Apply(content);
         }
     }
 }

--- a/Assets/Rector/Scripts/UI/GraphPages/KeyboardGuideView.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/KeyboardGuideView.cs
@@ -33,6 +33,9 @@ namespace Rector.UI.GraphPages
         // 差し替え接続はSubmitとの同時押し。併記のまま「SHIFT+Z/SPACE」にすると長すぎるので主キーだけ書く
         const string ParamComboKey = ParamKey + "+Z";
 
+        readonly InputGuideChip panChip;
+        readonly InputGuideChip zoomChip;
+        readonly InputGuideChip resetChip;
         readonly InputGuideChip lockChip;
         readonly InputGuideChip paramChip;
         readonly InputGuideChip grabChip;
@@ -49,9 +52,12 @@ namespace Rector.UI.GraphPages
 
             // パン・ズーム・リセットはステートに依らず常に効くので、文言は作ったきり触らない
             var viewRow = CreateRow();
-            viewRow.Add(new InputGuideChip(PanKey, "PAN"));
-            viewRow.Add(new InputGuideChip(ZoomKey, "ZOOM"));
-            viewRow.Add(new InputGuideChip(ResetKey, "RESET"));
+            panChip = new InputGuideChip(PanKey, "PAN");
+            zoomChip = new InputGuideChip(ZoomKey, "ZOOM");
+            resetChip = new InputGuideChip(ResetKey, "RESET");
+            viewRow.Add(panChip);
+            viewRow.Add(zoomChip);
+            viewRow.Add(resetChip);
             Add(viewRow);
 
             var modifierRow = CreateRow();
@@ -77,10 +83,10 @@ namespace Rector.UI.GraphPages
             Add(actionRow);
         }
 
-        public void Apply(GuideContent content, bool grabHeld, bool lockHeld)
+        public void Apply(GuideContent content)
         {
-            lockChip.SetState(true, lockHeld);
-            grabChip.SetState(content.Grab, grabHeld);
+            lockChip.SetState(true, false);
+            grabChip.SetState(content.Grab, false);
             muteChip.SetState(content.Mute, false);
 
             paramChip.SetKey(content.ParamCombo ? ParamComboKey : ParamKey);
@@ -91,6 +97,24 @@ namespace Rector.UI.GraphPages
             SetFace(faceLeft, content.FaceLeft);
             SetFace(faceRight, content.FaceRight);
             SetFace(faceBottom, content.FaceBottom);
+        }
+
+        public void SetPressed(GuideInput input, bool value)
+        {
+            switch (input)
+            {
+                case GuideInput.FaceTop: faceTop.SetPressed(value); break;
+                case GuideInput.FaceLeft: faceLeft.SetPressed(value); break;
+                case GuideInput.FaceRight: faceRight.SetPressed(value); break;
+                case GuideInput.FaceBottom: faceBottom.SetPressed(value); break;
+                case GuideInput.UpperLeft: lockChip.SetPressed(value); break;
+                case GuideInput.UpperRight: grabChip.SetPressed(value); break;
+                case GuideInput.LowerLeft: muteChip.SetPressed(value); break;
+                case GuideInput.LowerRight: paramChip.SetPressed(value); break;
+                case GuideInput.Pan: panChip.SetPressed(value); break;
+                case GuideInput.Zoom: zoomChip.SetPressed(value); break;
+                case GuideInput.Reset: resetChip.SetPressed(value); break;
+            }
         }
 
         /// <summary>空きポジションは「-」の減光表示にして、何も無いことを見せる。</summary>

--- a/Assets/Rector/Scripts/UI/GraphPages/PadGuideView.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/PadGuideView.cs
@@ -96,7 +96,7 @@ namespace Rector.UI.GraphPages
 
         public void SetXbox(bool xbox) => names = xbox ? XboxNames : DualShockNames;
 
-        public void Apply(GuideContent content, bool grabHeld, bool lockHeld)
+        public void Apply(GuideContent content)
         {
             SetFace(faceTop, names.FaceTop, content.FaceTop, names.FaceIsSymbol);
             SetFace(faceLeft, names.FaceLeft, content.FaceLeft, names.FaceIsSymbol);
@@ -104,15 +104,31 @@ namespace Rector.UI.GraphPages
             SetFace(faceBottom, names.FaceBottom, content.FaceBottom, names.FaceIsSymbol);
 
             lockChip.SetKey(names.UpperLeft);
-            lockChip.SetState(true, lockHeld);
+            lockChip.SetState(true, false);
             grabChip.SetKey(names.UpperRight);
-            grabChip.SetState(content.Grab, grabHeld);
+            grabChip.SetState(content.Grab, false);
             muteChip.SetKey(names.LowerLeft);
             muteChip.SetState(content.Mute, false);
             // 差し替え接続は下面ボタンとの同時押しなので、そのまま「R1+✕」と見せる
             paramChip.SetKey(content.ParamCombo ? $"{names.LowerRight}+{names.FaceBottom}" : names.LowerRight);
             paramChip.SetAction(content.Param ?? InputGuideContents.ParamLabel);
             paramChip.SetState(content.Param != null, content.ParamActive);
+        }
+
+        /// <summary>スティック側(Pan/Zoom/Reset)はこのレイアウトに載せていないので無視する。</summary>
+        public void SetPressed(GuideInput input, bool value)
+        {
+            switch (input)
+            {
+                case GuideInput.FaceTop: faceTop.SetPressed(value); break;
+                case GuideInput.FaceLeft: faceLeft.SetPressed(value); break;
+                case GuideInput.FaceRight: faceRight.SetPressed(value); break;
+                case GuideInput.FaceBottom: faceBottom.SetPressed(value); break;
+                case GuideInput.UpperLeft: lockChip.SetPressed(value); break;
+                case GuideInput.UpperRight: grabChip.SetPressed(value); break;
+                case GuideInput.LowerLeft: muteChip.SetPressed(value); break;
+                case GuideInput.LowerRight: paramChip.SetPressed(value); break;
+            }
         }
 
         /// <summary>空きポジションは「-」の減光表示にして、何も無いことを見せる。</summary>


### PR DESCRIPTION
Closes #100

The guide already had a pressed look — the inverted chip — but only the hold-style inputs used it: `LOCK`, `GRAB` and `PARAM`. Pressing square or L1 did nothing. This spreads the existing inversion across every chip. No new visual is introduced.

Covers the eight buttons the guide shows, plus the keyboard-only `PAN` / `ZOOM` / `RESET` rows. A chip lights only while the button is physically held, and a dimmed (unavailable) chip never lights.

## Which phase reports a press

Not uniform, and the reason is worth recording. An `InputAction`'s phases depend both on its interaction and on whether the control is digital. Two rules came out of reading `InputActionState.ProcessDefaultInteraction` and checking the phases in play mode:

**`started` fires at `actuation > 0`; `performed` only at the press threshold (0.5).**

So `started`/`canceled` is right for digital buttons but wrong for the analog triggers behind `Lock` and `GrabModifier` — a half-pulled L2 would light the chip while the feature stayed dormant. Those two read `performed`/`canceled` instead, which is also what they already used to drive `lockStarted` and `grabModifierHeld`. (Caught in review; the first cut had this bug.)

**`Tap` delivers `performed` on release and never `canceled`.**

So `Cancel` and `AddNode` cannot report a press. Both share a physical button with a `Hold` action bound to exactly the same paths — circle is `Cancel` + `RemoveEdge`, triangle is `AddNode` + `RemoveNode` — so the `Hold` one stands in. `Hold` does deliver `canceled` on release, including after its own `performed`.

Pan and zoom come from Value-typed actions that already keep their vector around, so a non-zero value is the press.

## Structure

`GraphInputAction` holds one `ReactiveProperty<bool>` per guide position, addressed by a new `GuideInput` enum; the view subscribes. Nothing clears them on `Disable()` — `InputActionMap.Disable` resets every in-flight action through `ResetActionState`, which delivers `canceled`, so leaving the page mid-press already puts the chips out.

`InputGuideChip` keeps the state-driven inversion and the press separately and ORs them, so a press cannot erase what a state was showing. `LockHeld` is removed, its only reader having moved to the press property.

## Verification

Confirmed on real hardware by @shivaduke28: every chip lights while held and clears on release, including the two Tap-adjacent ones (X and C), and the analog triggers now light exactly when the feature engages.

Reviewed by a subagent against the Input System package sources; three findings applied (the analog trigger bug above, an incorrect comment about `Disable()` not delivering `canceled`, and an unused `using`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112RNESeRSJEspazF2vboVy