### PR TITLE
change: drop the side padding on HUD text and tighten the font's spacing (issue #111)

### DIFF
--- a/Assets/Rector/StaticResources/FontAssets/JetBrains_Mono/JetBrainsMono-Thin_SDF.asset
+++ b/Assets/Rector/StaticResources/FontAssets/JetBrains_Mono/JetBrainsMono-Thin_SDF.asset
@@ -2794,7 +2794,7 @@ MonoBehaviour:
   - regularTypeface: {fileID: 0}
     italicTypeface: {fileID: 0}
   m_RegularStyleWeight: 0
-  m_RegularStyleSpacing: 14
+  m_RegularStyleSpacing: 8
   m_BoldStyleWeight: 0.75
   m_BoldStyleSpacing: 7
   m_ItalicStyleSlant: 35

--- a/Assets/Rector/StaticResources/UI/StyleSheets/RectorNode.uss
+++ b/Assets/Rector/StaticResources/UI/StyleSheets/RectorNode.uss
@@ -70,7 +70,7 @@
 
 .rector-node-slot-name-label {
     font-size: 10px;
-    padding: 0 2px;
+    padding: 0;
     margin-left: 4px;
     display: none;
     position: absolute;

--- a/Assets/Rector/StaticResources/UI/StyleSheets/RectorStyles.uss
+++ b/Assets/Rector/StaticResources/UI/StyleSheets/RectorStyles.uss
@@ -306,7 +306,8 @@
     margin: 0;
     font-size: 10px;
     letter-spacing: 2px;
-    padding: 2px 6px;
+    /* HUD の文字は左右に余白を置かない。上下は枠との重なりを作るために残す */
+    padding: 2px 0;
     -unity-text-align: middle-left;
     color: var(--rector-text-color);
     background-color: var(--rector-text-background-color);
@@ -440,18 +441,19 @@
 }
 
 /* 同じ色の下地を2つに割り、キー名だけ枠で囲む。押すものが四角として立つ。
-   動作側の透明な枠は、枠の有無で箱の高さがずれないようにするためのもの。
-   枠のぶんpaddingを1px詰めて、増える幅を隙間と枠だけに抑えている */
+   動作側の透明な枠は、枠の有無で箱の高さがずれないようにするためのもの。 */
 .rector-input-guide__key,
 .rector-input-guide__action {
     margin: 0;
-    padding: 0 5px;
+    padding: 0;
     border-width: 1px;
     border-color: rgba(0, 0, 0, 0);
     background-color: var(--rector-text-background-color);
 }
 
+/* 枠の中は押すものなので、枠と文字がくっつかないぶんだけ左右を残す */
 .rector-input-guide__key {
+    padding: 0 2px;
     border-color: rgba(255, 255, 255, 0.25);
 }
 
@@ -460,8 +462,9 @@
     border-color: rgba(0, 0, 0, 0);
 }
 
+/* キーの枠と動作の間。左右の余白を落としたぶん、ここだけは隙間で離す */
 .rector-input-guide__action {
-    margin-left: 2px;
+    margin-left: 5px;
 }
 
 .rector-input-guide__chip--active .rector-input-guide__key,


### PR DESCRIPTION
Closes #111

## 左右の余白を落とす

グラフページの文字は左右に余白を置かない作りで通してきたが、あとから足した2つが自前の padding を持っていて、そこだけ間延びしていた。

| | 前 | 後 |
|---|---|---|
| `.rector-group-label` | `2px 6px` | `2px 0`（上下は枠との重なりを作るので残す） |
| `.rector-input-guide__action` | `0 5px` | `0` |
| `.rector-input-guide__key` | `0 5px` | `0 2px`（枠の中は押すものなので、枠と文字がくっつかないぶんだけ残す） |
| `.rector-node-slot-name-label` | `0 2px` | `0` |

キーと動作の間は、余白ではなく `.rector-input-guide__action` の `margin-left` を `2px → 5px` にして離した。板の中の余白ではなく板と板の隙間なので、そちらが筋。

system 画面の 8px は #101 で意図的に揃えたばかりなので触っていない。

## 字送り

`JetBrainsMono-Thin_SDF.asset` の `m_RegularStyleSpacing` が **14** で、JetBrains Mono 本来の送りに全文字ぶん上乗せしていた。これが「間延びしてる」の正体。**8** にした。

実測（18px の `RectorApp ver.0.2.0`、19文字）:

| spacing | 幅 | 1文字の送り |
|---|---|---|
| 14（前） | 251 | 13.2 |
| **8（後）** | **232** | **12.2** |
| 0（フォント本来） | 206 | 10.8 = 0.6em |

USS の `letter-spacing` で相殺する案も試したが、効きが弱いうえに原因の場所ではないので採らなかった。`.rector-group-label` と `.rector-input-guide__chip` の `letter-spacing: 2px` は札としての見せ方なのでそのまま。

## Verification

- プレイモードで実測（HUD はスクリーンショットに写らないので `unity command eval` で `resolvedStyle` と `worldBound` を読む）
  - group ラベル `w=64 → 47`、guide key `w=26 → 19`、guide action `w=41 → 28`
  - キーと動作の板の隙間 `2 → 5`
  - `letter-spacing: 2px` の2箇所が維持されている
- EditMode テスト 46/46
- フォントアセットの差分は `m_RegularStyleSpacing` の1行だけ（動的に足されたグリフが焼き込まれないよう、プレイモードを止めてから反映している）

🤖 Generated with [Claude Code](https://claude.com/claude-code)