### PR TITLE
fix: paint the create node menu background in a single layer

### DIFF
--- a/Assets/Rector/StaticResources/UI/StyleSheets/RectorStyles.uss
+++ b/Assets/Rector/StaticResources/UI/StyleSheets/RectorStyles.uss
@@ -352,7 +352,8 @@
 }
 
 .rector-create-node-menu-list > .rector-button > Button {
-    background-color: rgba(20, 20, 20, 0.7);
+    /* カテゴリ列と同じ濃さ。2列は横に並ぶので下地は1つに揃える */
+    background-color: rgba(15, 15, 15, 0.76);
     font-size: 12px;
 }
 
@@ -375,7 +376,9 @@
 }
 
 .rector-node-category-button-inner {
-    background-color: rgba(20, 20, 20, 0.7);
+    /* ラベルが .rector-label で黒0.2を重ねていてテキスト側だけ濃かったので、下地はここ1枚に集約する。
+       rgba(15, 15, 15, 0.76) は rgba(20, 20, 20, 0.7) に黒0.2を重ねた合成値 */
+    background-color: rgba(15, 15, 15, 0.76);
     border-width: 0;
     margin: 0;
     padding: 0;
@@ -389,6 +392,11 @@
 
 .rector-node-category-button--focused > .rector-node-category-button-inner {
     background-color: black;
+}
+
+/* .rector-label(RectorCommon) の背景を消す。同スペシフィシティだとそちらが勝つので子セレクタで上書きする */
+.rector-node-category-button-inner > .rector-label {
+    background-color: rgba(0, 0, 0, 0);
 }
 
 .rector-node-category-button-icon {


### PR DESCRIPTION
Closes #114

## 原因

`NodeCategoryButton` は Button の中に icon と label を並べる構造で、下地は Button 側
(`.rector-node-category-button-inner`) が `rgba(20, 20, 20, 0.7)` で塗っている。
ところが label は `.rector-label` (`RectorCommon.uss:38`) を持っていて、その上に
`--rector-text-background-color` (黒 0.2) をもう一枚重ねてしまう。

| 領域 | レイヤー | 実効値 |
|---|---|---|
| アイコン 16px + 右マージン 4px | 下地1枚 | `rgba(20, 20, 20, 0.7)` |
| ラベル | 下地 + 黒0.2 の2枚 | 合成で `rgba(15, 15, 15, 0.76)` |

アイコン側のほうが下のグラフを多く透かすので明るく見える。#77 (`ee409cf`) で
ノードに対して直したのと同じ構図。

## 修正

`RectorStyles.uss` のみ。C# の変更はなし。

- `.rector-node-category-button-inner` の下地を合成値 `rgba(15, 15, 15, 0.76)` にする
- `.rector-node-category-button-inner > .rector-label` で label 側の背景を消す
  - `.rector-label` と同スペシフィシティだと RectorCommon が勝つので子セレクタで上書きする
- サブ列 (`.rector-create-node-menu-list > .rector-button > Button`) も同じ値に揃える

アイコン側ではなくテキスト側（濃いほう）に寄せているのは、下が透ける量が減って
視認性が上がるため。サブ列も一緒に上げたのは、2列が `flex-direction: row` で横に
並んでいて、今回見えていた 0.7 と 0.76 の差が列間に移るだけになるから。

フォーカス時の `black` は両方とも変更なし。

## 動作確認

プレイモードで `resolvedStyle` を実測。

```
cat inner bg=RGBA(0.059, 0.059, 0.059, 0.760)
  child VisualElement [rector-node-category-button-icon] bg=RGBA(0, 0, 0, 0)
  child Label [... rector-label]                        bg=RGBA(0, 0, 0, 0)
sub inner bg=RGBA(0.059, 0.059, 0.059, 0.760)
フォーカス行は両方とも RGBA(0, 0, 0, 1.000)
```

2列とも同値、アイコンとラベルは自前の背景を持たず、フォーカスの黒はそのまま。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLexCLt14im1XfGofaQsZG