### PR TITLE
change: widen the gaps in the keyboard guide (issue #117)

### DIFF
--- a/Assets/Rector/Scripts/UI/GraphPages/KeyboardGuideView.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/KeyboardGuideView.cs
@@ -23,7 +23,7 @@ namespace Rector.UI.GraphPages
         const string ResetKey = "P";
         const string LockKey = "TAB";
         const string ParamKey = "SHIFT";
-        const string GrabKey = "OPTION";
+        const string GrabKey = "ALT";
         const string FaceTopKey = "C";
         const string FaceLeftKey = "F";
         const string FaceRightKey = "X/ESC";

--- a/Assets/Rector/StaticResources/UI/StyleSheets/RectorStyles.uss
+++ b/Assets/Rector/StaticResources/UI/StyleSheets/RectorStyles.uss
@@ -459,9 +459,11 @@
     background-color: var(--rector-text-background-color);
 }
 
-/* 枠の中は押すものなので、枠と文字がくっつかないぶんだけ左右を残す */
+/* 枠の中は押すものなので、キーらしく見えるだけの余白を左右に残す。
+   letter-spacingは最後の文字の後ろにも乗り、その分(2px)は右の余白として見える。
+   左右を同じ幅に見せるには右をそのぶん引いておく(左5px / 右3+2px) */
 .rector-input-guide__key {
-    padding: 0 2px;
+    padding: 0 3px 0 5px;
     border-color: rgba(255, 255, 255, 0.25);
 }
 
@@ -526,7 +528,9 @@
 }
 
 /* パッド版は透明セルが間隔を持つが、こちらはチップを直接並べるのでチップ側に持たせる。
-   縦は行がベタづきしないよう横より広く取る（行間は上下の合計で4px） */
+   横はチップ内のキー→動作(5px)より広く取らないとチップの切れ目が読めないので、
+   間隔は左マージンだけで作る。右に余りを出さないので行の右端は親のright:8pxに揃う。
+   縦は行がベタづきしない程度でよく、上下の合計で4px */
 .rector-input-guide__keyboard .rector-input-guide__chip {
-    margin: 2px;
+    margin: 2px 0 2px 12px;
 }


### PR DESCRIPTION
Closes #117

## 原因

キーボードガイドはチップを横に流すが、間隔がチップの内側より狭かった。

| 区切り | 実効値 |
|---|---|
| チップ **間** (`.rector-input-guide__keyboard .rector-input-guide__chip` の `margin: 2px`) | 2 + 2 = **4px** |
| チップ **内** のキー枠 → 動作ラベル (`.rector-input-guide__action` の `margin-left`) | **5px** |

区切りの広さが逆転しているので、チップの切れ目が自分の内側の割れ目より弱く見え、
`[F] ACTION` と `[X/ESC]` が1本の文字列に溶けていた。

## 修正

`RectorStyles.uss` と `KeyboardGuideView.cs` の定数1つ。

- **チップ間 4px → 12px**。左マージンだけで作るので右に余りが出ず、各行の右端は
  親の `right: 8px` にぴったり揃う（従来は2px内側）。行間は上下2pxずつのまま
- **キーの左右余白 `0 2px` → `0 3px 0 5px`**。`letter-spacing: 2px` は最後の文字の
  後ろにも乗るため、左右同値だと見た目が「左2px / 右3.5px」と右に寄る。右から
  そのぶん引いて「左5px / 右4.5px」に均した
- **`GrabKey` を `OPTION` → `ALT`**。バインドは `RectorInput.inputactions` の
  `<Keyboard>/alt` で、他のキー名 (TAB / SHIFT / ESC / SPACE) とも表記が揃う

## 動作確認

プレイモードでビジュアルツリーを歩いて `worldBound` を実測。

チップ間隔（`inner` はキー枠→動作、`between` は前のチップの右端との距離）:

```
key='C'       act='-'     inner=5  between=-1
key='F'       act='-'     inner=5  between=12
key='X/ESC'   act='BACK'  inner=5  between=12
key='Z/SPACE' act='OK'    inner=5  between=12
key='V'       act='MUTE'  inner=5  between=12
```

3行とも右端が `x=1857` で一致。

キーの箱幅（JetBrains Mono は等幅で1文字あたり advance 5 + letter-spacing 2 = 7px）:

| | before | after |
|---|---|---|
| 1文字キーの箱幅 | 12.5px | 16.5px |
| 見た目の余白（左 / 右） | 2 / 3.5 | 5 / 4.5 |

`.rector-input-guide__key` はパッド表示とも共有なので、そちらの固定130pxセルが
溢れないことも確認した。最長は `[△] ADD (DELETE)` の107pxで23px余る。

```
cell w=130 used=107 [△][ADD (DELETE)]
cell w=130 used=65  [□][ACTION]
cell w=130 used=58  [◯][(CUT)]
cell w=130 used=51  [✕][SLOT]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLexCLt14im1XfGofaQsZG
