### PR TITLE
add: copy the selected node with R1 + triangle (issue #119)

### DIFF
--- a/Assets/Rector/Scripts/RectorLogger.cs
+++ b/Assets/Rector/Scripts/RectorLogger.cs
@@ -102,6 +102,12 @@ namespace Rector
             LogInternal($"[NODE/DELETE] id={node.Id} name='{node.Name}'");
         }
 
+        /// <summary>テンプレートの登録が消えていてコピーを作れなかった。</summary>
+        public static void NodeCopySkipped(Node node)
+        {
+            LogInternal($"[NODE/COPY_SKIPPED] id={node.Id} name='{node.Name}'");
+        }
+
         public static void CreateEdge(Edge edge, Node output, Node input)
         {
             LogInternal($"[EDGE/CREATE] src=({output.Id},{output.Name},{edge.OutputSlot.Name}) dst=({input.Id},{input.Name},{edge.InputSlot.Name})");

--- a/Assets/Rector/Scripts/UI/GraphPages/GraphPage.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/GraphPage.cs
@@ -34,6 +34,7 @@ namespace Rector.UI.GraphPages
         readonly VisualElement root;
 
         readonly GraphInputAction graphInputAction;
+        readonly NodeTemplateRepository nodeTemplateRepository;
 
         public readonly LayeredGraph Graph;
         public readonly NodeGroups Groups = new();
@@ -68,6 +69,7 @@ namespace Rector.UI.GraphPages
             NodeTemplateRepository nodeTemplateRepository)
         {
             this.graphInputAction = graphInputAction;
+            this.nodeTemplateRepository = nodeTemplateRepository;
 
             // VisualElements
             root = container.Q<VisualElement>(RootName);
@@ -189,6 +191,30 @@ namespace Rector.UI.GraphPages
         {
             Graph.AddNode(nodeView, SelectedNode?.Group ?? 0);
             Sort();
+        }
+
+        /// <summary>
+        /// 選択中のノードと同じ種類のノードを1つ足す。値もエッジも引き継がない。
+        /// </summary>
+        /// <remarks>
+        /// 選択は動かさない。連打でいくつでも増やせるし、押しっぱなしのR1で出ている
+        /// パラメータパネルも元のノードのまま出し続けられる。
+        /// AddNode が選択中のノードのグループへ入れるので、コピーは元と同じグループに並ぶ。
+        /// </remarks>
+        public void CopySelectedNode()
+        {
+            if (SelectedNode is not { } selected) return;
+
+            var source = selected.NodeView.Node;
+            // BGシーンをアンロードした後の SceneLocal ノードなど、テンプレートの登録が
+            // 消えているものは作り直せない
+            if (!nodeTemplateRepository.TryGet(source.TemplateId, out var template))
+            {
+                RectorLogger.NodeCopySkipped(source);
+                return;
+            }
+
+            AddNode(template.Create(NodeId.Generate()));
         }
 
         /// <summary>

--- a/Assets/Rector/Scripts/UI/GraphPages/InputGuideContents.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/InputGuideContents.cs
@@ -75,6 +75,7 @@ namespace Rector.UI.GraphPages
             },
             [GraphPageState.NodeParameter] = new GuideContent
             {
+                FaceTop = "COPY",
                 FaceLeft = "STEP",
                 FaceRight = "CLOSE",
                 Mute = true,

--- a/Assets/Rector/Scripts/UI/GraphPages/NodeParameterInputHandler.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/NodeParameterInputHandler.cs
@@ -21,5 +21,9 @@ namespace Rector.UI.GraphPages
 
         // パネル表示中のミュート(L1/V)がここに届く
         public override void Mute() => graphPage.ToggleMute(graphPage.SelectedNode);
+
+        // R1(SHIFT)を握ったままの△(C)。ノード選択中と同じボタンだが、
+        // 向こうが「作成メニューを開く」なのに対しこちらは「同じ種類をもう1個足す」
+        public override void AddNode() => graphPage.CopySelectedNode();
     }
 }


### PR DESCRIPTION
Closes #119

## What

R1 (SHIFT) を握るとノードパラメータのステートに入るが、そこの △ ボタンは何も割り当たっていなかった。ここに「選択中と同じ種類のノードをもう1個足す」を割り当てた。作成メニューを開いてカテゴリを辿り直さなくても、2個目のVFXや2個目のオペレータが同時押し1回で置ける。

キーアサインの検討は issue で相談済み:

- コピー範囲は **ノード単体のみ**（値もエッジも引き継がない）
- キーは **R1 + △ / SHIFT+C**
- コピー後の選択は **元のノードに残す**（連打でN個作れる。パラメータパネルも張り直さずに済む）

## How

- `GraphPage.CopySelectedNode()`: 選択中ノードの `TemplateId` からテンプレートを引いて `Create` → `AddNode`。テンプレートの登録が消えているもの（BGシーンをアンロードした後の SceneLocal ノード）はログを残して何もしない
- `NodeParameterInputHandler.AddNode()` をそこへ繋ぐ。**新しい InputAction もバインディングも追加していない**（`RectorInput.inputactions` は無変更）。同じ物理ボタンの Hold 側（RemoveNode）はこのステートで誰も拾っていないので衝突もない
- ガイドは `InputGuideContents` の NodeParameter に `FaceTop = "COPY"` を足すだけ。Pad/Keyboard 両ビューが同じ表を見ているので View 側は無変更

## Verification

- コンパイルエラー 0
- EditMode テスト 46/46 パス
- `dotnet format` 差分なし
- プレイモードで実動確認（Float ノードを選択 → NodeParameter の handler の `AddNode()` を叩く）:
  ```
  0 Float group=1 selected=True    # 元
  1 Float group=1 selected=False   # コピー
  edges 0
  ```
  同じグループに増え、選択は元ノードに残り、エッジは張られない

🤖 Generated with [Claude Code](https://claude.com/claude-code)