### PR TITLE
chore: bump version to 1.0.0 and rename the product to Rector

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,15 +147,15 @@ unity command eval 'return UnityEditor.AssetDatabase.FindAssets("t:VisualEffectA
 
 ### Driving a build
 
-`unity command --runtime RectorApp` connects to a running Player, so a build
+`unity command --runtime Rector` connects to a running Player, so a build
 processing live audio can be inspected and driven exactly like the editor.
 Placement of `--runtime` does not matter — commander.js claims it wherever it
 appears — but put it before the command name for readability. When no matching
 Player is found the call fails; it never silently answers from the editor.
 
 Watch the shell instead: **zsh does not word-split unquoted parameters**, so
-`FLAGS="--runtime RectorApp"; unity command $FLAGS rector_state` passes one
-argument `--runtime RectorApp`, which is not recognised and the call goes to
+`FLAGS="--runtime Rector"; unity command $FLAGS rector_state` passes one
+argument `--runtime Rector`, which is not recognised and the call goes to
 the editor. Write the flags out, or use an array.
 
 `Base.unity` carries a `RuntimePipelineManager` with `enableInBuilds` on, which

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -13,7 +13,7 @@ PlayerSettings:
   useOnDemandResources: 0
   accelerometerFrequency: 60
   companyName: DefaultCompany
-  productName: RectorApp
+  productName: Rector
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}
@@ -147,7 +147,7 @@ PlayerSettings:
   loadStoreDebugModeEnabled: 0
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
-  bundleVersion: 0.2.0
+  bundleVersion: 1.0.0
   preloadedAssets:
   - {fileID: -944628639613478452, guid: baec9e465f79b7c42a17e31a9c1e8758, type: 3}
   metroInputSource: 0


### PR DESCRIPTION
Closes #123

## 変更内容

- `ProjectSettings.asset`: `productName` を `RectorApp` → `Rector`
- `ProjectSettings.asset`: `bundleVersion` を `0.2.0` → `1.0.0`
- `CLAUDE.md`: `--runtime RectorApp` → `--runtime Rector`（3箇所）

C# の変更はありません。`HudModel.VersionText` は `Application.productName` /
`Application.version` を参照しているため、HUD の表示は自動的に
`Rector ver.1.0.0` になります。

## `--runtime` への影響

`unity command --runtime <name>` はプロセス名（`.app/Contents/MacOS/` の実行
ファイル名）で Player を探します。この実行ファイル名は `productName` から
決まるため（`.app` のファイル名はビルド時の保存名で別物）、リネーム後は
`--runtime Rector` になります。CLAUDE.md をそれに合わせました。

## 既知の影響: 保存済みグラフプリセット

`Application.persistentDataPath` が

- 旧: `~/Library/Application Support/DefaultCompany/RectorApp/graphs/`
- 新: `~/Library/Application Support/DefaultCompany/Rector/graphs/`

に移動するため、保存済みのプリセットは手動で移す必要があります。移行処理は
入れず、リリースノートに記載する方針としました。

`companyName` と `applicationIdentifier` は URP テンプレートの値のままですが、
今回は変更していません（bundle identifier を変えると macOS のマイク許可が
リセットされ、再要求が発生するため）。

## リリース手順（マージ後）

ローカルに孤児タグ `v1.0.0`（`b5fab9e`、2025-07-06 の workflow 失敗の残骸で
main の祖先ではなく origin にも存在しない）が残っているため、先に削除が必要です。

```
git tag -d v1.0.0
git switch main && git pull --ff-only
git tag -a v1.0.0 -m "Release version 1.0.0"
git push origin v1.0.0
gh release create v1.0.0 --generate-notes --title v1.0.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)