### PR TITLE
Move HUD app name and version to RectorSettings (issue #127)

### DIFF
--- a/Assets/Rector/Scripts/RectorInstaller.cs
+++ b/Assets/Rector/Scripts/RectorInstaller.cs
@@ -102,7 +102,13 @@ namespace Rector
                 confirmDialog,
                 graphPage,
                 hudView.SystemPageView));
-            var hudModel = Register(new HudModel(hudView, graphPage, scenePage, menuPage, memoryStatsRecorder));
+            var appName = string.IsNullOrEmpty(rectorSettingsAsset.hudSettings.appName)
+                ? Application.productName
+                : rectorSettingsAsset.hudSettings.appName;
+            var appVersion = string.IsNullOrEmpty(rectorSettingsAsset.hudSettings.version)
+                ? Application.version
+                : rectorSettingsAsset.hudSettings.version;
+            var hudModel = Register(new HudModel(hudView, graphPage, scenePage, menuPage, memoryStatsRecorder, appName, appVersion));
 
             Register(new NodeTemplateRegisterer(
                 nodeTemplateRepository,

--- a/Assets/Rector/Scripts/RectorSettings.cs
+++ b/Assets/Rector/Scripts/RectorSettings.cs
@@ -8,8 +8,19 @@ namespace Rector
     [CreateAssetMenu(fileName = "RectorSettings", menuName = "Rector/SettingsAsset", order = 100)]
     public sealed class RectorSettingsAsset : ScriptableObject
     {
+        public HudSettings hudSettings;
         public SceneSettings sceneSettings;
         public VfxSettings vfxSettings;
+    }
+
+    [Serializable]
+    public sealed class HudSettings
+    {
+        [Tooltip("HUDヘッダに表示する名前。空なら Product Name を使う")]
+        public string appName = "";
+
+        [Tooltip("HUDヘッダに表示するバージョン。空なら Player Settings の Version を使う")]
+        public string version = "1.0.0";
     }
 
     [Serializable]

--- a/Assets/Rector/Scripts/UI/Hud/HudModel.cs
+++ b/Assets/Rector/Scripts/UI/Hud/HudModel.cs
@@ -32,7 +32,7 @@ namespace Rector.UI.Hud
         int dtCount;
         float fpsUpdateTime;
 
-        public readonly string VersionText = $"{Application.productName} ver.{Application.version}";
+        public string VersionText { get; }
 
         readonly CompositeDisposable disposable = new();
 
@@ -41,8 +41,11 @@ namespace Rector.UI.Hud
             GraphPage graphPage,
             ScenePageModel scenePageModel,
             SystemPageModel systemPageModel,
-            MemoryStatsRecorder memoryStatsRecorder)
+            MemoryStatsRecorder memoryStatsRecorder,
+            string appName,
+            string version)
         {
+            VersionText = $"{appName} ver.{version}";
             this.view = view;
             this.memoryStatsRecorder = memoryStatsRecorder;
 

--- a/Assets/Rector/Settings/RectorSettings.asset
+++ b/Assets/Rector/Settings/RectorSettings.asset
@@ -12,6 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 460b9ddb55af44f78afdfa8d4e4b6b94, type: 3}
   m_Name: RectorSettings
   m_EditorClassIdentifier: 
+  hudSettings:
+    appName: Rector
+    version: 1.0.0
   sceneSettings:
     sceneNames:
     - Room

--- a/Assets/Rector/StaticResources/UI/Hud.uxml
+++ b/Assets/Rector/StaticResources/UI/Hud.uxml
@@ -3,7 +3,7 @@
     <Style src="project://database/Assets/Rector/StaticResources/UI/StyleSheets/RectorStyles.uss?fileID=7433441132597879392&amp;guid=6e4bceee306bbe249afe4a80e1779567&amp;type=3#RectorStyles" />
     <engine:VisualElement name="header" class="rector-hud-header">
         <engine:VisualElement class="rector-hud-logo" />
-        <engine:Label text="Rector App ver.0.1.0" name="version-label" class="rector-label rector-hud-version-label" />
+        <engine:Label text="Rector ver.1.0.0" name="version-label" class="rector-label rector-hud-version-label" />
     </engine:VisualElement>
     <engine:VisualElement name="body" class="rector-hud-body">
         <engine:VisualElement name="side-left" class="rector-hud-content-side-left" />


### PR DESCRIPTION
## Summary
- HUDヘッダの表示名とバージョンを `Application.productName` / `Application.version` 直読みから `RectorSettingsAsset` の新設 `HudSettings`（`appName` / `version`）に移した
- どちらも空欄の場合は従来どおり Player Settings（Product Name / Version）にフォールバックする
- Product Name はビルドの実行ファイル名経由で unity-cli の `--runtime` ターゲティングに使われるため、HUD表示名と分離することで自由にカスタムできるようになる（com.unity.pipeline のランタイム記述子は productName を持たず、プロセス名マッチのみであることを確認済み）
- `Hud.uxml` のプレースホルダを実値に合わせて `Rector ver.1.0.0` に更新

## Changes
- `RectorSettings.cs`: `HudSettings`（`appName`, `version`、デフォルト `"1.0.0"`）を追加
- `HudModel.cs`: `VersionText` を get-only プロパティ化し、コンストラクタ引数の `appName` / `version` から組み立て
- `RectorInstaller.cs`: 空欄フォールバックを解決して `HudModel` に注入
- `RectorSettings.asset`: `hudSettings: { appName: Rector, version: 1.0.0 }` を追加
- `Hud.uxml`: プレースホルダ文字列の更新

## Verification
- worktree の2台目エディタ（port 7801）でプレイモード検証:
  - 既定値で `Rector ver.1.0.0`（従来表示を維持）
  - `appName=FeiRine, version=2.5.0` で `FeiRine ver.2.5.0` に追従
  - `appName` 空欄で `Application.productName` にフォールバック
- batchmode コンパイルチェック・`console --level error` ともにエラーなし
- `dotnet format` 適用済み

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)