### PR TITLE
fix: resync keyboard state when entering the system page (issue #126)

### DIFF
--- a/Assets/Rector/Scripts/UI/Hud/SystemPageModel.cs
+++ b/Assets/Rector/Scripts/UI/Hud/SystemPageModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using R3;
 using Rector.UI.GraphPages;
+using UnityEngine.InputSystem;
 
 namespace Rector.UI.Hud
 {
@@ -93,6 +94,14 @@ namespace Rector.UI.Hud
 
         public void Enter(Action onExitAction)
         {
+            // ALT/Shift は macOS では差分イベント(flagsChanged)でしか届かず、フォーカスが
+            // 切れている間に取りこぼすと押下状態が反転したまま自己回復しない。
+            // ここでOSの実状態を再送させて矯正する。コストはキー1回押した分と同じ。
+            if (Keyboard.current is { } keyboard)
+            {
+                InputSystem.TrySyncDevice(keyboard);
+            }
+
             onExit = onExitAction;
             isVisible.Value = true;
             // 閉じずに Enter された場合に前のフォーカスが残らないよう、先に外してから先頭へ戻す


### PR DESCRIPTION
Closes #126

## 原因

macOSではモディファイアキー（ALT/Shift）は keyDown/keyUp ではなく flagsChanged（差分イベント）でしか届かない。ウィンドウのドラッグ等でフォーカスが切れている間に遷移を1回取りこぼすと、Unityネイティブ層の押下/解放の位相が1つズレ、「押すと未押下・離すと押下」の反転状態が固定されて自己回復しない。

- 通常キー（F等）はイベント種類自体が押下/解放を表すため、取りこぼしても次の1押しで自然回復する。モディファイアだけが構造的にこの問題を持つ
- Rector側の `grabModifierHeld` は performed/canceled のエッジ駆動ラッチなので、ズレたイベント列を何回受けても位相ズレは直せない
- Input System 1.20.0（最新）時点でパッケージ側の修正なし。GLFW/Flutter/Firefox も同型のバグを踏んでおり、flagsChanged の差分解釈に共通する既知の地雷

## 対策

System画面に遷移したタイミング（`SystemPageModel.Enter`）で `InputSystem.TrySyncDevice(Keyboard.current)` を実行する。バックエンドがOSの絶対状態をイベント1個として再送するため、stateバッファとネイティブ側の位相がまとめて現実に矯正される。コストはキー1回押した分と同等。

## 検証

エディタのプレイモードで実測:

1. ALT押下イベントを注入してスタック状態を作成 → `grabModifierHeld=true` が放置しても解除されないことを確認
2. ALTビットを保持したままBackspaceを注入してSystem画面を開く → `grabModifierHeld=false` に矯正されることを確認（syncの応答以外に解放状態を運べる経路がない状況での検証）
3. 実機でも、反転状態を再現した上で `TrySyncDevice` により正常復帰することを確認済み

## 補足

`OpenNodeParameter`（`<Keyboard>/shift`）も同型のホールド修飾のため同じバグを踏み得るが、System画面遷移時のsyncはキーボード全体を矯正するので合わせてカバーされる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)