### PR TITLE
change: unify node copy to triangle while grabbing with R2 (issue #131)

### DIFF
--- a/Assets/Rector/Scripts/UI/GraphPages/GraphPage.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/GraphPage.cs
@@ -64,6 +64,8 @@ namespace Rector.UI.GraphPages
 
         public bool IsNodeParameterOpen => graphInputAction.IsNodeParameterOpen;
 
+        public bool IsGrabbing => graphInputAction.GrabModifierHeld.CurrentValue;
+
         public GraphPage(VisualElement container,
             GraphInputAction graphInputAction,
             NodeTemplateRepository nodeTemplateRepository)
@@ -197,8 +199,8 @@ namespace Rector.UI.GraphPages
         /// 選択中のノードと同じ種類のノードを1つ足す。値もエッジも引き継がない。
         /// </summary>
         /// <remarks>
-        /// 選択は動かさない。連打でいくつでも増やせるし、押しっぱなしのR1で出ている
-        /// パラメータパネルも元のノードのまま出し続けられる。
+        /// 選択は動かさない。R2で掴んだまま連打でいくつでも増やせるし、掴んでいるのは
+        /// 元のノードのままなのでそのままグループ移動を続けられる。
         /// AddNode が選択中のノードのグループへ入れるので、コピーは元と同じグループに並ぶ。
         /// </remarks>
         public void CopySelectedNode()

--- a/Assets/Rector/Scripts/UI/GraphPages/InputGuideContents.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/InputGuideContents.cs
@@ -75,7 +75,6 @@ namespace Rector.UI.GraphPages
             },
             [GraphPageState.NodeParameter] = new GuideContent
             {
-                FaceTop = "COPY",
                 FaceLeft = "STEP",
                 FaceRight = "CLOSE",
                 Mute = true,
@@ -84,6 +83,19 @@ namespace Rector.UI.GraphPages
             },
         };
 
-        public static GuideContent Get(GraphPageState state) => Contents[state];
+        // R2(ALT)で掴んでいる間のノード選択。△がコピーになり、長押し削除は効かない
+        static readonly GuideContent NodeSelectionGrab = new()
+        {
+            FaceTop = "COPY",
+            FaceLeft = "ACTION",
+            FaceRight = "(CUT)",
+            FaceBottom = "SLOT",
+            Mute = true,
+            Param = ParamLabel,
+            Grab = true,
+        };
+
+        public static GuideContent Get(GraphPageState state, bool grabbing) =>
+            grabbing && state == GraphPageState.NodeSelection ? NodeSelectionGrab : Contents[state];
     }
 }

--- a/Assets/Rector/Scripts/UI/GraphPages/InputGuideView.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/InputGuideView.cs
@@ -20,6 +20,7 @@ namespace Rector.UI.GraphPages
         readonly KeyboardGuideView keyboardView = new();
 
         GraphPageState currentState;
+        bool grabbing;
 
         public InputGuideView()
         {
@@ -41,6 +42,13 @@ namespace Rector.UI.GraphPages
             state.Subscribe(x =>
             {
                 currentState = x;
+                UpdateContent();
+            }).AddTo(disposables);
+
+            // R2(ALT)で掴んでいる間は△の表記がCOPYに変わる
+            input.GrabModifierHeld.Subscribe(x =>
+            {
+                grabbing = x;
                 UpdateContent();
             }).AddTo(disposables);
 
@@ -72,7 +80,7 @@ namespace Rector.UI.GraphPages
 
         void UpdateContent()
         {
-            var content = InputGuideContents.Get(currentState);
+            var content = InputGuideContents.Get(currentState, grabbing);
             padView.Apply(content);
             keyboardView.Apply(content);
         }

--- a/Assets/Rector/Scripts/UI/GraphPages/NodeParameterInputHandler.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/NodeParameterInputHandler.cs
@@ -21,9 +21,5 @@ namespace Rector.UI.GraphPages
 
         // パネル表示中のミュート(L1/V)がここに届く
         public override void Mute() => graphPage.ToggleMute(graphPage.SelectedNode);
-
-        // R1(SHIFT)を握ったままの△(C)。ノード選択中と同じボタンだが、
-        // 向こうが「作成メニューを開く」なのに対しこちらは「同じ種類をもう1個足す」
-        public override void AddNode() => graphPage.CopySelectedNode();
     }
 }

--- a/Assets/Rector/Scripts/UI/GraphPages/NodeSelectionInputHandler.cs
+++ b/Assets/Rector/Scripts/UI/GraphPages/NodeSelectionInputHandler.cs
@@ -55,6 +55,14 @@ namespace Rector.UI.GraphPages
 
         public override void AddNode()
         {
+            // R2(ALT)で掴んでいる間の△(C)はコピー。未選択でも作成メニューへは倒さない。
+            // R2押下中はd-padがグループ移動に取られてメニューが操作不能になるため
+            if (graphPage.IsGrabbing)
+            {
+                graphPage.CopySelectedNode();
+                return;
+            }
+
             graphPage.State.Value = GraphPageState.NodeCreation;
         }
 
@@ -84,16 +92,20 @@ namespace Rector.UI.GraphPages
 
         public override void RemoveNode(HoldState state)
         {
+            // 掴んでいる間の△はコピーなので、握りすぎてホールドが成立しても削除しない
             switch (state)
             {
                 case HoldState.Start:
+                    if (graphPage.IsGrabbing) break;
                     graphPage.ShowHoldNextToSelected();
                     break;
                 case HoldState.Cancel:
                     graphPage.HideHold();
                     break;
                 case HoldState.Perform:
+                    // ガイドは無条件に消す。非Grabで押し始めてからR2を握った場合の残留を防ぐ
                     graphPage.HideHold();
+                    if (graphPage.IsGrabbing) break;
                     graphPage.RemoveSelectedNode();
 
                     break;


### PR DESCRIPTION
Closes #131

## 概要

ノードコピーを R2 (Grab) 中の三角に一本化する。「掴んで増やす」方が R1+三角 のコードより操作として自然なため、#119 / #121 で入れた R1 経由のコピーは削除した。

## 変更内容

- **Grab 中の三角 tap でコピー**: `NodeSelectionInputHandler.AddNode()` が `GraphPage.IsGrabbing`（`IsNodeParameterOpen` と同型の新プロパティ）で分岐。コピー後も選択・Grab 対象は元ノードのままなので、連打で量産しつつグループ移動を続けられる
- **Grab 中の三角長押し（削除）を抑止**: コピーのつもりで握りすぎたときの誤削除防止。ホールドガイドも出さない（`HideHold` は残留防止のため無条件に呼ぶ）
- **R1+三角のコピーを削除**: `NodeParameterInputHandler.AddNode` の override を削除し no-op に戻した
- **入力ガイド**: R2 押下中の NodeSelection のみ三角の表示が「COPY」になり、離すと「ADD (DELETE)」に戻る。NodeParameter の「COPY」表示は削除

Grab 中は作成メニューへフォールバックしない（未選択でも）。R2 押下中は d-pad がグループ移動に取られてメニューが操作不能になるため。

## 確認

- EditMode テスト 50/50 パス（batchmode）
- 実機確認済み（worktree4 の2台目エディタ）:
  - R2+△tap → 同グループにコピー、選択・Grab 矢印は元ノードのまま、連打可
  - R2 なし △tap → 作成メニュー（回帰）
  - R1+△tap → 何も起きない
  - R2+△長押し → 何も起きない、ガイド残留なし
  - ガイドは R2 押下中のみ「COPY」

🤖 Generated with [Claude Code](https://claude.com/claude-code)
