### PR TITLE
chore: bump version to 1.1.0 (issue #133)

### DIFF
--- a/Assets/Rector/Settings/RectorSettings.asset
+++ b/Assets/Rector/Settings/RectorSettings.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   hudSettings:
     appName: Rector
-    version: 1.0.0
+    version: 1.1.0
   sceneSettings:
     sceneNames:
     - Room

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -147,7 +147,7 @@ PlayerSettings:
   loadStoreDebugModeEnabled: 0
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
-  bundleVersion: 1.0.0
+  bundleVersion: 1.1.0
   preloadedAssets:
   - {fileID: -944628639613478452, guid: baec9e465f79b7c42a17e31a9c1e8758, type: 3}
   metroInputSource: 0


### PR DESCRIPTION
## Summary
- Bump `PlayerSettings.bundleVersion` from 1.0.0 to 1.1.0
- Bump `version` in `RectorSettings.asset` (HUD display, introduced in #128) to 1.1.0

Refs #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)